### PR TITLE
[docker] Support for Elasticsearch 6.x

### DIFF
--- a/docker/Dockerfile-full
+++ b/docker/Dockerfile-full
@@ -17,13 +17,14 @@
 FROM grimoirelab/installed
 MAINTAINER Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
 
-ENV ES=elasticsearch-5.6.3
-ENV KB=kibiter-5.6.0-1
+ENV ES=elasticsearch-6.1.0
+ENV KB=kibiter-6.1.0-1
 
-# Install OpenJDK-8
+# Install OpenJDK-8 & netstat (for monitoring)
 RUN sudo mkdir /usr/share/man/man1 && \
     sudo apt-get update && \
-    sudo apt-get -y install --no-install-recommends openjdk-8-jdk-headless
+    sudo apt-get -y install --no-install-recommends openjdk-8-jdk-headless \
+      net-tools
 
 # Install ElasticSearch
 RUN wget https://artifacts.elastic.co/downloads/elasticsearch/${ES}.deb && \
@@ -32,9 +33,11 @@ RUN wget https://artifacts.elastic.co/downloads/elasticsearch/${ES}.deb && \
     rm ${ES}.deb ${ES}.deb.sha512
 #    shasum -a 512 -c ${ES}.deb.sha512 && \
 RUN echo "http.host: 0.0.0.0" > /tmp/elasticsearch.yml && \
+    echo "cluster.routing.allocation.disk.watermark.flood_stage: 99.9%" >> /tmp/elasticsearch.yml && \
     echo "cluster.routing.allocation.disk.watermark.low: 99.9%" >> /tmp/elasticsearch.yml && \
     echo "cluster.routing.allocation.disk.watermark.high: 99.9%" >> /tmp/elasticsearch.yml && \
-    sudo mv /tmp/elasticsearch.yml  /etc/elasticsearch/elasticsearch.yml
+    sudo mv /tmp/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml && \
+    sudo chown -R elasticsearch.elasticsearch /usr/share/elasticsearch
 EXPOSE 9200
 
 # Install MariaDB
@@ -48,16 +51,13 @@ RUN sudo echo "mysqld_safe &" > /tmp/config && \
     sudo rm -f /tmp/config
 
 # Install Kibana
-RUN wget https://github.com/grimoirelab/kibiter/releases/download/kibiter-v5.6.0/${KB}-linux-x86_64.tar.gz && \
+RUN wget https://github.com/grimoirelab/kibiter/releases/download/kibiter-v6.1.0/${KB}-linux-x86_64.tar.gz && \
     tar xzf ${KB}-linux-x86_64.tar.gz && \
     echo "server.host: 0.0.0.0" > ${KB}-linux-x86_64/config/kibana.yml
 # Run Kibana until optimization is done, to avoid optimizing everything
 # time the image is run
 RUN ${KB}-linux-x86_64/bin/kibana 2>&1 | grep -m 1 "Optimization of .* complete in .* seconds"
 EXPOSE 5601
-
-# Install netstat (for monitoring)
-RUN sudo apt-get -y install --no-install-recommends net-tools
 
 ADD docker/mordred-full.cfg /mordred-full.cfg
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -246,7 +246,7 @@ project.
 To try it, you can just run it as follows:
 
 ```bash
-$ docker run -p 127:0.0.1:5601:5601 \
+$ docker run -p 127.0.0.1:5601:5601 \
     -v $(pwd)/mordred-local.cfg:/mordred-local.cfg \
     -t grimoirelab/full
 ```
@@ -268,7 +268,7 @@ a dashboard for the GrimoireLab project will be produced. Once produced,
 you can just point your browser to http://localhost:5601 and voila.
 
 The `docker run` command line above exposed port 5601 in the container to
-be reachable from the host, as `localhost:5601`. If you omit "127:0.0.1:",
+be reachable from the host, as `localhost:5601`. If you omit "127.0.0.1:",
 it will be reachable to any other machine reaching your host, so be careful:
 by default there is no access control in the Kibiter used by this container.
 
@@ -443,18 +443,18 @@ directory:
 ```
 $ docker run \
     -v $(pwd)/docker/dist:/dist -v $(pwd)/docker/logs:/logs \
-    grimoirelab/factory --build --install --check
+    grimoirelab/factory
 ```
 
 If instead of the default release (`releases/latest`)
 you want to run some other,
-use the following line (in this case, to build `elasticgirl.27.1`):
+use the following line (in this case, to build `elasticgirl.29`):
 
 ```
 $ docker run \
     -v $(pwd)/docker/dist:/dist \
     -v $(pwd)/docker/logs:/logs \
-    -v $(pwd)/releases/elasticgirl.27.1:/release \
+    -v $(pwd)/releases/elasticgirl.29:/release \
     grimoirelab/factory --build --install --check --relfile /release
 ```
 
@@ -491,12 +491,12 @@ api-token = XXX
 Save the file as `mordred-local.cfg` and run the container image as:
 
 ```
-$ docker run -p 127:0.0.1:5601:5601 \
+$ docker run -p 127.0.0.1:5601:5601 \
     -v $(pwd)/mordred-local.cfg:/mordred-local.cfg \
     -t grimoirelab/full
 ```
 
-Now, point your web broser at `http://127:0.0.1:5601`,
+Now, point your web broser at `http://127.0.0.1:5601`,
 and you should see the dashboard.
 
 If you prefer to use `grimoirelab/installed`,

--- a/docker/entrypoint-full.sh
+++ b/docker/entrypoint-full.sh
@@ -47,12 +47,16 @@ echo "Waiting for Kibiter index to be created..."
 until $(curl --output /dev/null --silent --fail http://127.0.0.1:9200/.kibana/config/_search ); do
     printf '.'
     sleep 2
+    curl -XPOST "http://127.0.0.1:5601/api/kibana/settings/indexPattern:placeholder" \
+      -H 'Content-Type: application/json' -H 'kbn-version: 6.1.0-1' \
+      -H 'Accept: application/json' -d '{"value": "*"}' \
+      --silent --output /dev/null
 done
 echo "Kibiter started"
 
-if [[ $RUN_MORDRED ]] && $RUN_MORDRED = "NO" ; then
+if [[ $RUN_MORDRED ]] && [[ $RUN_MORDRED = "NO" ]]; then
   echo
-  echo "All services up, not running Mordred because $RUN_MORDRED = NO"
+  echo "All services up, not running Mordred because RUN_MORDRED = NO"
   echo "Get a shell running docker exec, for example:"
   echo "docker exec -it" $(hostname) "env TERM=xterm /bin/bash"
 else


### PR DESCRIPTION
Now Dockerfile-full installs Elasticsearch 6.1 and Kibiter 6.1.

All GrimoireLab tools already support these versions, except some minor issues with panels.