### PR TITLE
[build_grimoirelab] Add check that tools can be run

### DIFF
--- a/utils/build_grimoirelab
+++ b/utils/build_grimoirelab
@@ -26,13 +26,14 @@ import logging
 import os
 import os.path
 import shutil
+import sys
 import subprocess
 import tempfile
 
-description = """Create packages for pypi.
+description = """Create pypi pacakges for GrimoireLab.
 
 Example:
-    build_pypi.py
+    build_grimoirelab --build --distdir /tmp/dist
 
 """
 
@@ -45,38 +46,48 @@ all_repos = {
             'version_file': os.path.join('grimoirelab', 'toolkit', '_version.py')}],
     'perceval': [{'name': 'perceval', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-perceval',
-            'version_file': os.path.join('perceval', '_version.py')}],
+            'version_file': os.path.join('perceval', '_version.py'),
+            'check_run': 'perceval --help'}],
     'perceval-mozilla': [{'name': 'perceval-mozilla', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-perceval-mozilla',
-            'version_file': 'setup.py'}],
+            'version_file': 'setup.py',
+            'check_run': 'perceval kitsune --help'}],
     'perceval-opnfv': [{'name': 'perceval-opnfv', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-perceval-opnfv',
-            'version_file': 'setup.py'}],
+            'version_file': 'setup.py',
+            'check_run': 'perceval functest --help'}],
     'perceval-puppet': [{'name': 'perceval-puppet', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-perceval-puppet',
-            'version_file': 'setup.py'}],
+            'version_file': 'setup.py',
+            'check_run': 'perceval puppetforge --help'}],
     'kingarthur': [{'name': 'kingarthur', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-kingarthur',
             'version_file': os.path.join('arthur', '_version.py'),
+            'check_run': 'arthurd --help',
             'tests': True}],
     'grimoireelk': [{'name': 'grimoire-elk', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-elk',
-            'version_file': os.path.join('grimoire_elk', '_version.py')}],
+            'version_file': os.path.join('grimoire_elk', '_version.py'),
+            'check_run': 'p2o.py --help'}],
     'sortinghat': [{'name': 'sortinghat', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-sortinghat',
-            'version_file': os.path.join('sortinghat', '_version.py')}],
+            'version_file': os.path.join('sortinghat', '_version.py'),
+            'check_run': 'sortinghat --help'}],
     'kidash': [{'name': 'kidash', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-kidash',
-            'version_file': os.path.join('kidash', '_version.py')}],
+            'version_file': os.path.join('kidash', '_version.py'),
+            'check_run': 'kidash --help'}],
     'sigils': [{'name': 'grimoirelab-panels', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-sigils',
             'version_file': os.path.join('panels', '_version.py')}],
     'manuscripts': [{'name': 'manuscripts', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-manuscripts',
-            'version_file': os.path.join('manuscripts', '_version.py')}],
+            'version_file': os.path.join('manuscripts', '_version.py'),
+            'check_run': 'manuscripts --help'}],
     'mordred': [{'name': 'grimoire-mordred', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-mordred',
-            'version_file': os.path.join('mordred', '_version.py')}],
+            'version_file': os.path.join('mordred', '_version.py'),
+            'check_run': 'mordred --help'}],
     'cereslib': [{'name': 'cereslib', 'dir': '',
             'repo_url': 'http://github.com/chaoss/grimoirelab-cereslib',
             'version_file': os.path.join('cereslib', '_version.py')}]
@@ -156,12 +167,15 @@ def parse_args ():
                                 + "installed too. "
                                 + "Ensure you have write permissions. "
                                 + "Use at your own risk.")
-
     parser.add_argument("--install_atonce", action='store_true',
                             default=False,
                             help="Install all packages at once (True) "
                                 + "or loop installing them once at a time "
                                 + "(False, default).")
+    parser.add_argument("--fail", action='store_true',
+                            default=False,
+                            help="Force the program to fail if checks "
+                                + "or installation fail.")
 
     args = parser.parse_args()
     return args
@@ -223,11 +237,16 @@ class CommandRunner (object):
     """Simple class for running commands."""
 
     @staticmethod
-    def run_command (args, cwd='/'):
+    def run_command (args, cwd='/', exit=True):
         """Run command in this virtual environment (except if self.system)
+
+        If exit=True, and the command fails, it will exit
+        printing the error when executing the command.
+        Otherwise, it prints with logging.debug.
 
         :param args: command line arguments (including 0)
         :param  cwd: working directory to use
+        :param exit: exit if command fails (bool)
         :return    : success status (boolean)
         """
 
@@ -239,13 +258,16 @@ class CommandRunner (object):
             output_fn("Command successful")
         else:
             success = False
-            output_fn = print
+            if exit:
+                output_fn = print
+            else:
+                output_fn = logging.debug
             output_fn("Command failed")
         output_fn('  command: ' + ' '.join(result.args))
         output = result.stdout.decode("utf-8", "backslashreplace")
         output_fn('  output: \n' + output)
-        if success == False:
-            exit()
+        if success == False and exit:
+            sys.exit(1)
         return (success, output)
 
     def clone_git(cls, repo, dir, commit):
@@ -305,41 +327,48 @@ class Venv (CommandRunner):
 
         self._boot.run_command(['python3', '-m', 'venv', self.name])
 
-    def update(self, module_names, dist_dir=None, atonce=False):
-        """Update virtual environment with some packages.
+    def rm(self):
 
-        Use the list of packages for pip installing them.
+        shutil.rmtree(self.name)
+
+    def update(self, module_names, dist_dir=None, atonce=False):
+        """Update virtual environment with some packages (modules).
+
+        Use the list of modules packages for pip installing them.
         If dist_dir is specified, use it for finding the packages
         in addition to pypi. If not, use pypi only.
         All packages can be installed at once (atonce=True),
         with a single pip invocation, or one by one, with
         separate pip commands, looping through the list.
 
-        :params     pkgs: list of packages to install
-        :params dist_dir: directory with packages to install
-        :params   atonce: install all packages at once or not (default: False).
+        :params module_names: list of packages names to install (strings)
+        :params     dist_dir: directory with packages to install
+        :params       atonce: install all packages at once or not (default: False).
+        :return:              update successful (bool)
     """
 
         common_args = ['pip3', 'install', '--upgrade']
         if dist_dir:
             common_args += ['--pre', '--find-links=' + dist_dir.name]
         if atonce:
-            self.run_command(common_args + module_names)
+            (success, output) = self.run_command(common_args + module_names)
         else:
             for pkg in module_names:
-                self.run_command(common_args + [pkg])
+                (success, output) = self.run_command(common_args + [pkg])
+        return success
 
     def print_installed(self):
         """Print list of installed packages."""
 
         self.run_command(['pip3', 'freeze'])
 
-    def run_command (self, args, cwd='/'):
+    def run_command (self, args, cwd='/', exit=True):
         """Run command in this virtual environment (except if self.system)
 
-        :param args: command line arguments (including 0)
+        :param args: command line arguments, including 0 (list)
         :param  cwd: working directory to use
-        :return    : success status (boolean)
+        :param exit: exit if command fails (bool)
+        :return    : list with success status (boolean) and output (string)
         """
 
         new_args = args
@@ -347,7 +376,7 @@ class Venv (CommandRunner):
             new_args[0] = args[0]
         else:
             new_args[0] = os.path.join(self.name, 'bin', args[0])
-        (success, output) = super().run_command(new_args, cwd=cwd)
+        (success, output) = super().run_command(new_args, cwd=cwd, exit=exit)
         return (success, output)
 
 
@@ -493,17 +522,28 @@ class ReleaseInfo(object):
         return self.info.keys()
 
 class Checker(object):
+    """Checks for a set of modules.
+
+    :param   modules: list of modules to check
+    :param repos_dir: directory for repositories (Directory)
+    :param  dist_dir: directory for distribution packages (Directory)
+    :param      fail: stop the program if checks fail, with errno (bool)
+    """
 
     _check_runner = CommandRunner()
 
-    def __init__(self, modules, repos_dir):
+    def __init__(self, modules, repos_dir, dist_dir, fail):
 
         self.modules = modules
         self.repos_dir = repos_dir
+        self.dist_dir = dist_dir
+        self.fail = fail
+        self.failures = []
 
     def check_version(self):
         """Check if commit changed version, for all modules."""
 
+        print("Checking versions...")
         for module_name in self.modules.names():
             desc = self.modules.descriptor(module_name)
             if 'version_file' in desc:
@@ -517,7 +557,77 @@ class Checker(object):
                     print("Checked version for " + module_name + ": OK")
                 else:
                     print("Checked version for " + module_name + ": Fail")
+                    self.failures.append("Failed version check for " + module_name)
 
+    def check_built(self):
+        """Check built modules.
+
+        Check that built packages are usable. This means they are
+        installable, and can be run.
+        """
+
+        if len(self.modules.names()) > 1:
+            self.check_installable(self.modules.names())
+        for module in self.modules.names():
+            venv = self.check_installable([module])
+            self.check_run(venv, module)
+
+    def check_installable(self, modules):
+        """Check that a list of modules are installable
+
+        The test is done in the corresponding virtual environment.
+
+        :param modules: list of module names (string)
+        :return:        installation virtual environment (Venv)
+        """
+
+        if len(modules) > 1:
+            check = "all modules at once"
+        else:
+            check = modules[0]
+        print("Checking installable (" + check + ")...", end='', flush=True)
+        install_venv = Venv(system=False,
+                        dependencies=install_dependencies,
+                        purpose="CheckInstallableVenv", persistent=False)
+        success = install_venv.update(module_names=modules,
+                                      dist_dir=self.dist_dir,
+                                      atonce=True)
+        if success:
+            print("OK")
+        else:
+            print("Fail")
+            self.failures.append("Failed installable (" + check + ")")
+        return install_venv
+
+    def check_run(self, venv, module):
+        """Check that the run command for a module can run
+
+        The test is done in the corresponding virtual environment.
+
+        :param module: module name (string)
+        """
+
+        desc = self.modules.descriptor(module)
+        if 'check_run' in desc:
+            print("Checking run (" + module + ")...", end='', flush=True)
+            command = desc['check_run'].split()
+            logging.debug("Running check run for {} as {}." \
+                          .format(module, command))
+            (success, output) = venv.run_command(command, exit=False)
+            if success:
+                print("OK")
+            else:
+                print("Fail")
+                self.failures.append("Failed check run (" + module + ")")
+        else:
+            logging.debug("No command to check run for {}." \
+                          .format(module))
+
+    def fail_if_failures(self):
+        if self.fail and (len(self.failures) > 0):
+            for failure in self.failures:
+                print(failure)
+            sys.exit(1)
 
 def main():
     args = parse_args()
@@ -537,10 +647,12 @@ def main():
     if (not args.build) and (not args.install) and (not args.check):
         args.build = True
 
-    if args.build:
-        print("Building...")
+    # We need repos_dir for building and/or checking
+    if args.build or args.check:
         repos_dir = Directory(name=args.reposdir, purpose="Repos",
                                 persistent=False)
+    if args.build:
+        print("Building...")
         venv = Venv(system=args.system, name=args.venv,
                     dependencies=build_dependencies,
                     purpose="Venv", persistent=False)
@@ -560,8 +672,11 @@ def main():
 
     if args.check:
         print("Checking...")
-        checker = Checker(modules=modules, repos_dir=repos_dir)
+        checker = Checker(modules=modules, repos_dir=repos_dir,
+                          dist_dir=dist_dir, fail=args.fail)
         checker.check_version()
+        checker.check_built()
+        checker.fail_if_failures()
 
     if args.install:
         print("Installed modules (all):")


### PR DESCRIPTION
This is a first try at improving the testing when producing packages for Pypi. Two new checks have been included:

* That each module can be installed alone (with its dependencies)
in a virtual environment.
* That one executable can be run for each package. Usually,
for each package, the main executable is run with the "--help"
argument.

The structure of the script is now more complete, paving the way for running the unit tests of each module.

Running build_grimoirelab as follows, uncovered three cases of packages that, when installed alone with their dependencies, cannot be run:

```
./build_grimoirelab --check --distdir /tmp/dist --reposdir /tmp/repos --relfile ../releases/18.04-02 --fail
...
Failed check run (grimoire-elk)
Failed check run (kidash)
Failed check run (grimoire-mordred)
```

I'm opening pull requests for these projects, fixing the problems.