### PR TITLE
[docker] Fix to let new certificates being built, and something else...

### DIFF
--- a/docker/Dockerfile-factory
+++ b/docker/Dockerfile-factory
@@ -63,4 +63,4 @@ ENV PYTHONUNBUFFERED 0
 # Entrypoint (build GrimoireLab packages), and default arguments for it
 ENTRYPOINT [ "/usr/local/bin/build_grimoirelab", "--distdir", "/dist", \
     "-l", "debug", "--logfile", "/logs/build.log" ]
-CMD [ "--build", "--install", "--check", "--relfile", "/release" ]
+CMD [ "--build", "--install", "--check", "--test", "--fail", "--relfile", "/release" ]

--- a/docker/Dockerfile-installed
+++ b/docker/Dockerfile-installed
@@ -71,7 +71,7 @@ ADD docker/orgs.json /orgs.json
 ADD docker/projects.json /projects.json
 ADD docker/identities.yaml /identities.yaml
 ADD docker/menu.yaml /menu.yaml
-ADD docker/panels ${DEPLOY_USER_DIR}/panels
+#ADD docker/panels ${DEPLOY_USER_DIR}/panels
 RUN /bin/ln -s /menu.yaml  ${DEPLOY_USER_DIR}/menu.yaml
 
 USER ${DEPLOY_USER}

--- a/docker/Dockerfile-secured
+++ b/docker/Dockerfile-secured
@@ -25,6 +25,8 @@ USER root
 # SearchGuard configuration for Elasticsearch
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install -b com.floragunn:search-guard-6:6.1.0-21.0 && \
     cd /usr/share/elasticsearch/plugins/search-guard-6/tools/ && \
+    rm install_demo_configuration.sh && \
+    wget https://raw.githubusercontent.com/floragunncom/search-guard/master/tools/install_demo_configuration.sh && \
     chmod 755 install_demo_configuration.sh && \
     ./install_demo_configuration.sh -y && \
     echo "searchguard.enterprise_modules_enabled: false" >> \


### PR DESCRIPTION
Demo certificates provided by search-guard did expire. To temporarily fix this, I got the new script which has embedded new certificates (check in docker/Dockerfile-secured).

Additionally, I'm starting to add support for tests in the installed container.