### PR TITLE
[build_grimoirelab] Improve support for testing

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -156,6 +156,16 @@ The file `repos.json` can be as follows:
 }
 ```
 
+* Run tests for all repos with tests activated (`test` is true),
+using for each repo the checkout in `18.06-02`,
+and prebuilt packages in the `dir` directory for Installing
+dependencies for running tests:
+
+```
+./build_grimoirelab --test --relfile 18.06-02 \
+  --distdir dist --fail
+```
+
 For complete list of arguments, run:
 
 ```bash

--- a/utils/README.md
+++ b/utils/README.md
@@ -171,3 +171,15 @@ For complete list of arguments, run:
 ```bash
 $ build_grimoirelab --help
 ```
+
+* In some cases, running tests require of using some specific files,
+such as customization files, that need to be copied to the repository
+where tests will be run. For that, we have the `--confdir` argument.
+`--confdir` specifies a directory where it is expected to have one
+subdirectory per module needing files to be copied,
+with files in the same relative path to where they should be copied.
+
+```
+./build_grimoirelab --test --relfile 18.06-02 \
+  --confdir conf --distdir dist --fail
+```

--- a/utils/build_grimoirelab
+++ b/utils/build_grimoirelab
@@ -716,11 +716,12 @@ def main():
                         persistent=True)
 
     # If no action is specified, let it be build
-    if (not args.build) and (not args.install) and (not args.check):
+    if (not args.build) and (not args.install) and (not args.check) \
+            and (not args.test):
         args.build = True
 
-    # We need repos_dir for building and/or checking
-    if args.build or args.check:
+    # We need repos_dir for building, checking and/or testing
+    if args.build or args.check or args.test:
         repos_dir = Directory(name=args.reposdir, purpose="Repos",
                                 persistent=False)
     if args.build:

--- a/utils/build_grimoirelab
+++ b/utils/build_grimoirelab
@@ -247,21 +247,33 @@ class CommandRunner (object):
     """Simple class for running commands."""
 
     @staticmethod
-    def run_command (args, cwd='/', exit=True):
+    def run_command (args, cwd='/', exit=True, env=None):
         """Run command in this virtual environment (except if self.system)
 
-        If exit=True, and the command fails, it will exit
+        If exit is True, and the command fails, it will exit
         printing the error when executing the command.
         Otherwise, it prints with logging.debug.
+        If env is None, keep the environment variables as they are currently.
+        If not, add these variables (in a dict) to the environment
+        variables of the subprocess executing the command.
 
         :param args: command line arguments (including 0)
         :param  cwd: working directory to use
         :param exit: exit if command fails (bool)
+        :param  env: environmment variables (dict), default: None
         :return    : success status (boolean) and output (string)
         """
 
+        if env is None:
+            env_vars = None
+        else:
+            env_vars = os.environ.copy()
+            env_vars.update(env)
+
         result = subprocess.run(args, cwd=cwd,
-                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                env=env_vars)
+
         if result.returncode == 0:
             success = True
             output_fn = logging.debug
@@ -375,12 +387,17 @@ class Venv (CommandRunner):
 
         self.run_command(['pip3', 'freeze'])
 
-    def run_command (self, args, cwd='/', exit=True):
+    def run_command (self, args, cwd='/', exit=True, env=None):
         """Run command in this virtual environment (except if self.system)
+
+        If env is None, keep the environment variables as they are currently.
+        If not, add these variables (in a dict) to the environment
+        variables of the subprocess executing the command.
 
         :param args: command line arguments, including 0 (list)
         :param  cwd: working directory to use
         :param exit: exit if command fails (bool)
+        :param  env: environmment variables (dict), default: None
         :return    : list with success status (boolean) and output (string)
         """
 
@@ -389,7 +406,8 @@ class Venv (CommandRunner):
             new_args[0] = args[0]
         else:
             new_args[0] = os.path.join(self.name, 'bin', args[0])
-        (success, output) = super().run_command(new_args, cwd=cwd, exit=exit)
+        (success, output) = super().run_command(new_args, cwd=cwd,
+                                                exit=exit, env=env)
         return (success, output)
 
 
@@ -518,14 +536,9 @@ class BuildingEnviron(object):
         setup_file = os.path.join(dir, 'setup.py')
         if os.path.isfile(setup_file):
             (success, output) \
-                = self.venv.run_command(['pip', 'install', '-e', '.',
-                                         '--find-links=' + self.dist_dir.name],
-                                         cwd=dir)
-            if not success:
-                return (False, output)
-            (success, output) \
                 = self.venv.run_command(['python', 'setup.py', 'test'],
-                                        cwd=dir)
+                                        cwd=dir,
+                                        env={'PIP_FIND_LINKS': self.dist_dir.name})
             return (success, output)
         else:
             logging.info("Directory " + dir + " does not have a setup.py file.")

--- a/utils/build_grimoirelab
+++ b/utils/build_grimoirelab
@@ -142,6 +142,10 @@ def parse_args ():
     parser.add_argument("--distdir", type=str,
                             help="Directory for storing dist packages. "
                                 + "If not specified, create a random directory.")
+    parser.add_argument("--confdir", type=str,
+                            help="Directory for testing configuration, "
+                                + "with one subdirectory per module with "
+                                + "testing configuration.")
 
     args_venv = parser.add_mutually_exclusive_group(required=False)
     args_venv.add_argument("--venv", type=str,
@@ -483,6 +487,25 @@ class BuildingEnviron(object):
             logging.info("Directory " + dir + " does not have a setup.py file.")
             return "Fail"
 
+    def _test_conf(self, conf_dir, repo_dir):
+        """Copy files in the test configuration directory to a repository.
+
+        Copy all the files (if any) in the test configuration directories,
+        with the same path, to the repository, which should be a clone
+        of the git repo to test.
+
+        :param conf_dir: test configuration directory
+        :param repo_dir: clone of the repository
+        """
+
+        for root, dirs, files in os.walk(conf_dir):
+            for file in files:
+                src = os.path.join(root, file)
+                dest = os.path.join(repo_dir, src[len(conf_dir)+1:])
+                os.makedirs(os.path.dirname(dest), exist_ok=True)
+                shutil.copyfile(src, dest)
+                logging.info("Copying testing config files: " + src + " to " + dest)
+
     def _test_dist(self, dir):
         """Test a Python directory (with a module)
 
@@ -520,8 +543,20 @@ class BuildingEnviron(object):
         print("Built module " + name + ": " + built)
         return(built)
 
-    def test_module(self, name):
-        """Test module, given its name."""
+    def test_module(self, name, conf_dir=None):
+        """Test module, given its name.
+
+        The git repository corresponding to the module will be cloned,
+        the files in the corresponding subdir of conf_dir (if any)
+        will be copied, with the same path,
+        to the clone of the git repo, an tests will be run.
+        Returns "OK" if all tests could be run, and didn't fail,
+        or "Fail" otherwise.
+
+        :param name: name of the module to test
+        :param conf_dir: name of the directory for configuration for testing
+        :return: "OK" or "Fail"
+        """
 
         desc = self.modules.descriptor(name)
         if 'test' in desc and desc['test']:
@@ -530,6 +565,11 @@ class BuildingEnviron(object):
             pkg_dir = os.path.join(self.repos_dir.name, desc['repo'], desc['dir'])
             if not os.path.isdir(repo_dir):
                 self._runner.clone_git(repo=repo_url, dir=repo_dir, commit=desc['commit'])
+            if conf_dir is not None:
+                conf_dir_module = os.path.join(conf_dir, name)
+                if os.path.isdir(conf_dir_module):
+                    print(conf_dir_module)
+                    self._test_conf(conf_dir_module, repo_dir)
             (success, output) = self._test_dist(pkg_dir)
             print("Tested module " + name + ": ", end='')
             if success:
@@ -743,7 +783,7 @@ def main():
             building = BuildingEnviron(modules=module, venv=venv,
                                        repos_dir=repos_dir, dist_dir=dist_dir,
                                        fail=args.fail)
-            result = building.test_module(module_name)
+            result = building.test_module(module_name, args.confdir)
             if result == 'Fail':
                 some_failed = True
         if args.fail and some_failed:


### PR DESCRIPTION
This patch improves support for testing GrimoireLab pip packages. Now, it allows to run `setup.py test` for each module, including configuration files for testing (eg, when they are needed to express addresses or credentials to access services). One of the commits also removes the need to build before testing, allowing that way to test already built packages (in fact, they will be used as dependencies, since unit tests will always be run on the source code).

Now, all build packages for a GrimoireLab distro can be tested by running (assuming built packages are in `dist`, configuration files for testing are in `testconf`, which will have one subdirectory per module with testing config files, with the same path they should be copied to the source code repo befor running tests, and `release` is the release file to test) :

```
$ python --test --distdir dist --fail --confdir testconf --relfile release 
```