### PR TITLE
Improvements for bulding packages

### DIFF
--- a/docker/ansible_release.yml
+++ b/docker/ansible_release.yml
@@ -9,6 +9,9 @@
 ## ansible-playbook ansible_release.yml --check --extra-vars "release=18.04-01" --tags "build"
 ## ansible-playbook ansible_release.yml --check --extra-vars "release=latest" --tags "build"
 ## ansible-playbook ansible_release.yml --check --extra-vars "release=18.04-01" --tags "push"
+##
+## Build Python packages and containers, not failing if something goes wrong
+## ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook ansible_release.yml --check --extra-vars "release=18.04-01 fail=" --tags "build"
 
 - name: Build grimoirelab/factory
   hosts: localhost
@@ -24,6 +27,8 @@
   tags:
     - build
     - build_pkgs
+  vars:
+    fail: "--fail"
   tasks:
     - name: "Create directories for packages and old packages"
       file:
@@ -46,6 +51,7 @@
           - "{{ playbook_dir }}/dist:/dist"
           - "{{ playbook_dir }}/logs:/logs"
           - "{{ playbook_dir }}/../releases/{{ release }}:/release"
+        command: "--build --install --check --test {{ fail }} --relfile /release"
         detach: False
       register: result
 
@@ -57,7 +63,7 @@
         volumes:
           - "{{ playbook_dir }}/dist:/dist"
           - "{{ playbook_dir }}/logs:/logs"
-        command: "--build --install --check --test --fail"
+        command: "--build --install --check --test {{ fail }}"
         detach: False
       register: result
 

--- a/utils/build_grimoirelab
+++ b/utils/build_grimoirelab
@@ -764,8 +764,14 @@ def main():
             repos = json.load(repos_file)
             all_repos.update(repos)
 
+    # Make the path absolute so it works when pip is invoked from venvs
+    if args.distdir:
+        distdir = os.path.abspath(args.distdir)
+    else:
+        distdir = None
+
     modules = Modules(module_names=args.modules, release=release)
-    dist_dir = Directory(name=args.distdir, purpose="Distribution",
+    dist_dir = Directory(name=distdir, purpose="Distribution",
                         persistent=True)
 
     # If no action is specified, let it be build


### PR DESCRIPTION
This includes two commits:

* Ansible playbook now allows for overriding the default behavior of failing if there are errors when building, installing or testing packages.
* `build_grimoirelab` now uses absolute paths for the dist directory.