### PR TITLE
[build_grimoirelab] Switch to better message when no release file

### DIFF
--- a/utils/build_grimoirelab
+++ b/utils/build_grimoirelab
@@ -821,7 +821,7 @@ def main():
     if release:
         gl_rel = release.get_commit('grimoirelab-rel')
     if (not release) or (not gl_rel):
-        gl_rel = 'Unknown'
+        gl_rel = 'Current master from git repos'
     print("GrimoireLab release:", gl_rel)
 
     if args.reposfile:


### PR DESCRIPTION
When no release file is provided, build_grimoirelab uses master for
all GrimoireLab git repos as the version to build. Instead of "Unknown",
let's call this "Current master from git repos"