### PR TITLE
[docker] Add new kibiter_url entry to infra.cfg

### DIFF
--- a/docker/mordred-infra.cfg
+++ b/docker/mordred-infra.cfg
@@ -46,3 +46,7 @@ orgs_file = /orgs.json
 # Identities file in GrimoireLab format
 identities_file = [/identities.yaml]
 identities_format = grimoirelab
+
+[panels]
+
+kibiter_url = http://localhost:5601


### PR DESCRIPTION
If not, the container, by default, fails.