### PR TITLE
fix frontmatter link to about page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@ sections:
   - name: Docs
     link: https://chaoss.github.io/grimoirelab-tutorial/
   - name: About
-    link: {{site.baseurl}}/#about
+    link: https://chaoss.github.io/grimoirelab/#about
 ---
 
 {% include header.html %}

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@ sections:
   - name: Docs
     link: https://chaoss.github.io/grimoirelab-tutorial/
   - name: About
-    link: #about
+    link: {{site.baseurl}}/#about
 ---
 
 {% include header.html %}


### PR DESCRIPTION
Still need to test this locally, but it appears the `about` link at the top of the page isn't correctly pointing to the footer element. Not sure if this is a jekyll problem or what, but this more direct link should work.