### PR TITLE
New directory for third party tools of interest for GrimoireLab

### DIFF
--- a/third-party/Dockerfile-fossology
+++ b/third-party/Dockerfile-fossology
@@ -1,0 +1,58 @@
+# Copyright (C) 2016-2017 Bitergia
+# GPLv3 License
+#
+# Build GrimoireLab packages, install them, check them
+#
+
+FROM debian:buster-slim
+#FROM debian:stretch-slim
+MAINTAINER Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+
+ENV DEBIAN_FRONTEND=noninteractive
+# install dependencies
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+    	devscripts \
+	fakeroot \
+	build-essential:native \
+	debhelper \
+	libglib2.0-dev \
+	libmagic-dev \
+	libxml2-dev \
+	libmxml-dev \
+	libtext-template-perl \
+	librpm-dev \
+	subversion \
+	rpm \
+	libpcre3-dev \
+	libssl-dev \
+	postgresql-server-dev-all \
+	libboost-regex-dev \
+	libboost-program-options-dev \
+	libjsoncpp-dev \
+	libjson-c-dev \
+	php-cli \
+	php-mbstring \
+	php-zip \
+	php-xml \
+	libboost-system-dev \
+	libboost-filesystem-dev \
+	curl \
+	ca-certificates \
+        && \
+    apt-get clean && \
+    find /var/lib/apt/lists -type f -delete
+
+#ENV LANG=en_US.UTF-8 \
+#    LANGUAGE=en_US:en \
+#    LC_ALL=en_US.UTF-8 \
+#    LANG=C.UTF-8
+
+ADD entrypoint-fossology.sh /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
+RUN mkdir /build
+WORKDIR /build
+
+# Entrypoint (build GrimoireLab packages), and default arguments for it
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ ]

--- a/third-party/Dockerfile-grimoirelab-nomos
+++ b/third-party/Dockerfile-grimoirelab-nomos
@@ -1,0 +1,26 @@
+# Copyright (C) 2016-2017 Bitergia
+# GPLv3 License
+#
+# Build GrimoireLab packages, install them, check them
+#
+
+FROM grimoirelab/full
+MAINTAINER Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ADD build/fossology-common_3.6.0-1_amd64.deb /tmp
+ADD build/fossology-nomos_3.6.0-1_amd64.deb /tmp
+# install dependencies
+RUN sudo apt-get update && \
+    sudo apt-get -y install /tmp/fossology-common_3.6.0-1_amd64.deb \
+    	/tmp/fossology-nomos_3.6.0-1_amd64.deb \
+        && \
+    sudo apt-get clean && \
+    sudo find /var/lib/apt/lists -type f -delete && \
+    sudo rm /tmp/fossology-common_3.6.0-1_amd64.deb \
+       /tmp/fossology-nomos_3.6.0-1_amd64.deb
+
+# Entrypoint
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "-c", "/infra.cfg", "/dashboard.cfg", "/project.cfg", "/override.cfg"]

--- a/third-party/README.md
+++ b/third-party/README.md
@@ -1,0 +1,30 @@
+# Directory for third party stuff
+
+This directory is for configuration files, data, documentation, etc,
+related to third party tools useful (or in some cases, needed)
+by GrimoireLab or some of the GrimoireLab tools.
+
+## Docker image grimoirelab/fossology-factory
+
+This image is for building the
+[Debian packages that are being produced in the Debian mentor program](https://mentors.debian.net/package/fossology).
+They are built from source code.
+For building them, we create a Docker image
+(`grimoirelab/fossology-factory`) and then run it:
+
+```bash
+$ docker build -f Dockerfile-fossology -t grimoirelab/fossology-factory .
+$ docker run -v $(pwd)/build:/build -t grimoirelab/fossology-factory
+```
+
+As a result, all packages (source and binary) are in the build directory.
+
+## Docker image grimoirelab/full-nomos
+
+This is a decendent image from grimoirelab/full, with the nomos
+binary in it, via the installation of the fosssology-nomos package
+built with `grimoirelab/fossology-factory`:
+
+```
+docker build -f Dockerfile-grimoirelab-nomos -t grimoirelab/full-nomos .
+```

--- a/third-party/entrypoint-fossology.sh
+++ b/third-party/entrypoint-fossology.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "Starting container:" $(hostname)
+
+echo "Getting FOSSology source package..."
+dget -u https://mentors.debian.net/debian/pool/main/f/fossology/fossology_3.6.0-1.dsc
+
+echo "Building packages..."
+cd fossology-3.6.0
+/usr/bin/debuild -us -uc
+echo "If FOSSology packages were built, look for them where you mounted /build"
+


### PR DESCRIPTION
For now, it inclues Dockerfiles and other related files to produce FOSSology Debian packages, via a Docker container, and a Docker container like grimoirelab/full with nomos also installed.
