### PR TITLE
Add missing Hatstall configuration

### DIFF
--- a/default-grimoirelab-settings/apache-hatstall.conf
+++ b/default-grimoirelab-settings/apache-hatstall.conf
@@ -1,0 +1,29 @@
+<VirtualHost *:80>
+	# Basic Apache config
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+
+	ErrorLog ${APACHE_LOG_DIR}/hatstall-error.log
+	CustomLog ${APACHE_LOG_DIR}/hatstall-access.log combined
+
+	Alias /static/ /home/grimoirelab/grimoirelab-hatstall/django-hatstall/static/
+
+	<Directory /home/grimoirelab/grimoirelab-hatstall/django-hatstall/static>
+		Require all granted
+	</Directory>
+
+	# WSGI specific config
+	LogLevel info
+
+	WSGIDaemonProcess hatstall python-path=/home/grimoirelab/grimoirelab-hatstall/django-hatstall/
+	WSGIProcessGroup hatstall
+
+	WSGIScriptAlias / /home/grimoirelab/grimoirelab-hatstall/django-hatstall/django_hatstall/wsgi.py process-group=hatstall
+
+	<Directory /home/grimoirelab/grimoirelab-hatstall/django-hatstall/django_hatstall/>
+		<Files wsgi*.py>
+			Require all granted
+		</Files>
+	</Directory>
+
+</VirtualHost>

--- a/default-grimoirelab-settings/shdb.cfg
+++ b/default-grimoirelab-settings/shdb.cfg
@@ -1,0 +1,5 @@
+[SHDB_Settings]
+user=root
+password=
+name=demo_sh
+host=mariadb

--- a/docker-compose/docker-compose-secured.yml
+++ b/docker-compose/docker-compose-secured.yml
@@ -22,8 +22,8 @@ services:
       links:
         - mariadb
       volumes:
-        - ./apache-hatstall.conf:/home/grimoirelab/apache-hatstall.conf
-        - ./shdb.cfg:/home/grimoirelab/shdb.cfg
+        - ../default-grimoirelab-settings/apache-hatstall.conf:/home/grimoirelab/apache-hatstall.conf
+        - ../default-grimoirelab-settings/shdb.cfg:/home/grimoirelab/shdb.cfg
 
     elasticsearch:
       image: bitergia/elasticsearch:6.1.0-secured

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       links:
         - mariadb
       volumes:
-        - ./apache-hatstall.conf:/home/grimoirelab/apache-hatstall.conf
-        - ./shdb.cfg:/home/grimoirelab/shdb.cfg
+        - ../default-grimoirelab-settings/apache-hatstall.conf:/home/grimoirelab/apache-hatstall.conf
+        - ../default-grimoirelab-settings/shdb.cfg:/home/grimoirelab/shdb.cfg
 
     elasticsearch:
       image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.4


### PR DESCRIPTION
Hatstall is missing its configuration, without which the user will just see the default Apache httpd landing page.  This commit adds the example configuration taken from the [Hatstall repo](https://github.com/chaoss/grimoirelab-hatstall).

Signed-off-by: Nick Jones <nick@dischord.org>