### PR TITLE
chore: update kibiter version

### DIFF
--- a/docker/Dockerfile-full
+++ b/docker/Dockerfile-full
@@ -18,7 +18,7 @@ FROM grimoirelab/installed
 MAINTAINER Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
 
 ENV ES=elasticsearch-6.1.4
-ENV KB_VERSION=6.1.4-1
+ENV KB_VERSION=6.1.4-4
 ENV KB_TAG=community-v${KB_VERSION}
 ENV KB=kibiter-${KB_VERSION}
 ENV KB_DIR=${KB}-linux-x86_64


### PR DESCRIPTION
Update the Kibiter version to address the [issues](https://github.com/chaoss/grimoirelab-kibiter/issues/119) found in version 6.1.4-1 in Docker images.