### PR TITLE
Update docker compose settings

### DIFF
--- a/default-grimoirelab-settings/setup-secured.cfg
+++ b/default-grimoirelab-settings/setup-secured.cfg
@@ -26,7 +26,6 @@ orgs_file = /home/bitergia/conf/organizations.json
 autoprofile = [github, pipermail, git]
 matching = [email]
 sleep_for = 100
-bots_names = []
 unaffiliated_group = Unknown
 affiliate = true
 strict_mapping = false

--- a/default-grimoirelab-settings/setup.cfg
+++ b/default-grimoirelab-settings/setup.cfg
@@ -26,7 +26,6 @@ orgs_file = /home/bitergia/conf/organizations.json
 autoprofile = [github, pipermail, git]
 matching = [email]
 sleep_for = 100
-bots_names = []
 unaffiliated_group = Unknown
 affiliate = true
 strict_mapping = false

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -47,7 +47,7 @@ services:
 
     mordred:
       restart: on-failure:5
-      image: bitergia/mordred:grimoirelab-0.2.31
+      image: bitergia/mordred:grimoirelab-0.2.33
       volumes:
         - ../default-grimoirelab-settings/setup.cfg:/home/bitergia/conf/setup.cfg
         - ../default-grimoirelab-settings/aliases.json:/home/bitergia/conf/aliases.json


### PR DESCRIPTION
This PR updates the setup.cfg files by removing the `bots_names` attribute and increase the image version number of mordred, which is now 0.2.33