### PR TITLE
make the setup-secured.cfg more like the unsecured cfg

### DIFF
--- a/default-grimoirelab-settings/setup-secured.cfg
+++ b/default-grimoirelab-settings/setup-secured.cfg
@@ -38,8 +38,8 @@ kibiter_time_from = now-5y
 kibiter_default_index = git
 kibiter_url = http://admin:admin@kibiter:5601
 kibiter_version = 6.1.4-5
-#gitlab-issues = true
-#gitlab-merges = true
+gitlab-issues = true
+gitlab-merges = true
 
 [phases]
 collection = true
@@ -65,6 +65,7 @@ studies = [enrich_demography:git, enrich_areas_of_code:git, enrich_onion:git]
 
 #[github]
 #api-token = <YOUR_API_TOKEN_WHERE>
+#enterprise-url = <YOUR_GITHUB_ENTERPRISE_URL>
 #raw_index = github_demo_raw
 #sleep-for-rate = true
 #sleep-time = "300"
@@ -75,7 +76,7 @@ studies = [enrich_demography:git, enrich_areas_of_code:git, enrich_onion:git]
 #raw_index = gitlab_issues_demo_raw
 #enriched_index = gitlab_issues_demo_enriched
 #no-archive = true
-#enterprise-url = https://gitlab.gnome.org
+#enterprise-url = <YOUR_GITLAB_INSTANCE_URL>
 #sleep-for-rate = true
 
 #[gitlab:merge]
@@ -83,7 +84,7 @@ studies = [enrich_demography:git, enrich_areas_of_code:git, enrich_onion:git]
 #raw_index = gitlab_merges_demo_raw
 #enriched_index = gitlab_merges_demo_enriched
 #no-archive = true
-#enterprise-url = https://gitlab.gnome.org
+#enterprise-url = <YOUR_GITLAB_INSTANCE_URL>
 #category = merge_request
 #sleep-for-rate = true
 


### PR DESCRIPTION
The 'setup-secured.cfg' had some content that diverged from the unsecured cfg version. 

This PR makes them more alike so that the differences become more apparent.