### PR TITLE
[third-party] Add nlp-rest-api tool

### DIFF
--- a/third-party/Dockerfile-grimoirelab-3p
+++ b/third-party/Dockerfile-grimoirelab-3p
@@ -16,11 +16,20 @@ RUN sudo apt-get update && \
     sudo apt-get -y install /tmp/fossology-common_3.6.0-1_amd64.deb \
     	/tmp/fossology-nomos_3.6.0-1_amd64.deb \
     	cloc \
+	    maven \
         && \
     sudo apt-get clean && \
     sudo find /var/lib/apt/lists -type f -delete && \
     sudo rm /tmp/fossology-common_3.6.0-1_amd64.deb \
        /tmp/fossology-nomos_3.6.0-1_amd64.deb
+
+VOLUME /tmp
+RUN git clone https://github.com/crossminer/nlp-rest-api && \
+    cd nlp-rest-api && mvn -N io.takari:maven:wrapper && ./mvnw install
+EXPOSE 8080
+
+ADD entrypoint-3p.sh /entrypoint.sh
+RUN sudo chmod 755 /entrypoint.sh
 
 # Entrypoint
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/third-party/entrypoint-3p.sh
+++ b/third-party/entrypoint-3p.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Start ElasticSearch, MariaDB and Kibana, wait for them to be listening,
+# and launch SirMordred with the options in the CMD line of the Dockerfile
+
+echo "Starting container:" $(hostname)
+
+# Start Elasticsearch
+echo "Starting Elasticsearch"
+sudo chown -R elasticsearch.elasticsearch /var/lib/elasticsearch
+sudo /etc/init.d/elasticsearch start
+status=$?
+if [ $status -ne 0 ]; then
+  echo "Failed to start Elasticsearch: $status"
+  exit $status
+fi
+
+echo "Waiting for Elasticsearch to start..."
+sudo netstat -cvulntp |grep -m 1 ".*:9200.*LISTEN.*"
+echo "Elasticsearch started"
+
+# Start MariaDB
+echo "Starting MariaDB"
+sudo /etc/init.d/mysql start
+status=$?
+if [ $status -ne 0 ]; then
+  echo "Failed to start MariaDB: $status"
+  exit $status
+fi
+
+echo "Waiting for MariaDB to start..."
+sudo netstat -cvulntp |grep -m 1 ".*:3306.*LISTEN.*"
+echo "MariaDB started"
+
+# Start Kibana
+echo "Starting Kibiter"
+${KB}-linux-x86_64/bin/kibana > kibana.log 2>&1 &
+
+echo "Waiting for Kibiter to start..."
+#sleep .2
+#sudo netstat -cvulntp |grep -m 1 ".*:5601.*LISTEN.*"
+until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:5601); do
+    printf '.'
+    sleep 2
+done
+echo "Kibiter started"
+
+echo "Starting nlp-rest-api"
+sudo java -jar nlp-rest-api/target/ehu-nlp-rest_api.jar > nlp-rest.log 2>&1 &
+echo "Waiting for nlp-rest-api to start..."
+until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:8080/emotion?text=test); do
+    printf '.'
+    sleep 2
+done
+echo "nlp-rest-api started"
+
+if [[ $RUN_MORDRED ]] && [[ $RUN_MORDRED = "NO" ]]; then
+  echo
+  echo "All services up, not running SirMordred because RUN_MORDRED = NO"
+  echo "Get a shell running docker exec, for example:"
+  echo "docker exec -it" $(hostname) "env TERM=xterm /bin/bash"
+elif [[ $TEST ]] && [[ $TEST = "YES" ]]; then
+  echo
+  echo "Testing GrimoireLab"
+  echo "Release file with commits to test in /release,"
+  echo "testing configuration files in /testconf,"
+  echo "Python packages to install as dependencies for testing in /dist"
+  if [[ $FAIL ]] && [[ $FAIL = "NO" ]]; then
+    echo "Not failing even if tests fail because FAIL=NO"
+    fail=""
+  else
+    fail="--fail"
+  fi
+  sleep 1
+  /usr/local/bin/build_grimoirelab --test --distdir /dist --confdir /testconf $fail
+  exit
+else
+  sleep 1
+  # Start SirMordred
+  echo "Starting SirMordred to build a GrimoireLab dashboard"
+  echo "This will usually take a while..."
+  /usr/local/bin/sirmordred $*
+  status=$?
+  if [ $status -ne 0 ]; then
+    echo "Failed to start SirMordred: $status"
+    exit $status
+  fi
+  echo
+  echo "SirMordred done, dashboard produced, check http://localhost:5601"
+  echo
+  echo "To make this shell finish, type <CTRL> C"
+  echo "but the container will still run services in the background,"
+  echo "including Kibiter and Elasticsearch, so you can still operate the dashboard."
+fi
+echo
+echo "To make the whole container finish, type 'docker kill " $(hostname) "'"
+sleep 5000d


### PR DESCRIPTION
This PR addresses https://github.com/chaoss/grimoirelab/issues/258

This code includes the nlp-rest-api tool (available at https://github.com/crossminer/nlp-rest-api), which
is able to derive sentiment and emotion data from text.

The dockerfile grimoirelab-3p file has been modified to download and compile this tool. The tool is exposed on the port 8080 by default, however such a port can be easily changed when executing the docker run command.

Furthermore, a new entrypoint script is provided. It extends the entrypoint-full (available in the docker folder) with the commands needed to start and initialize the nlp-rest-api service.

Things to be done:
- [ ] Add documentation to use the nlp-rest-tool