### PR TITLE
[third-party] Add Jadolint tool

### DIFF
--- a/third-party/Dockerfile-grimoirelab-3p
+++ b/third-party/Dockerfile-grimoirelab-3p
@@ -22,6 +22,8 @@ RUN sudo apt-get update && \
     sudo rm /tmp/fossology-common_3.6.0-1_amd64.deb \
        /tmp/fossology-nomos_3.6.0-1_amd64.deb
 
+RUN wget https://github.com/crossminer/crossJadolint/releases/download/Pre-releasev2/jadolint.jar
+
 # Entrypoint
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "-c", "/infra.cfg", "/dashboard.cfg", "/project.cfg", "/override.cfg"]


### PR DESCRIPTION
This PR addresses https://github.com/chaoss/grimoirelab/issues/262

This code includes the Jadolint tool (available at https://github.com/crossminer/crossJadolint), which
is able to extract dependencies from Dockerfiles.

The dockerfile grimoirelab-3p file has been modified to download and compile this tool.

Things to be done:
- [x] Ask to make public the Jadolint repo
- [x] Evaluate the results