### PR TITLE
[build_utils] replace "git -C" with "git -c"

### DIFF
--- a/utils/build_grimoirelab
+++ b/utils/build_grimoirelab
@@ -319,15 +319,15 @@ class CommandRunner (object):
             cls.run_command(['git', 'clone', repo, dir])
             logging.debug("Cloned: " + dir)
         logging.debug("Fetching: " + dir)
-        cls.run_command(['git', '-C', dir, 'fetch'])
+        cls.run_command(['git', '-c', dir, 'fetch'])
         logging.debug("Fetched: " + dir)
-        cls.run_command(['git', '-C', dir, 'checkout', commit])
+        cls.run_command(['git', '-c', dir, 'checkout', commit])
         logging.debug("Checked out: " + dir)
 
     def check_version(cls, dir, commit, version_file):
 
         logging.debug("Checking version in commit: " + dir)
-        (success, output) = cls.run_command(['git', '-C', dir, 'diff-tree',
+        (success, output) = cls.run_command(['git', '-c', dir, 'diff-tree',
                 '--no-commit-id', '--name-only', '-r', commit])
         check = False
         if success:


### PR DESCRIPTION
Command in Windows works, but in RHEL7 fails saying:
- Unknown option C

Per Git's config documentation (https://gitirc.eu/git-config.html):

core.ignorecase

If true, this option enables various workarounds to enable git to work better on filesystems that are not case sensitive, like FAT. For example, if a directory listing finds makefile when git expects Makefile, git will assume it is really the same file, and continue to remember it as Makefile.

The default is false, except git-clone(1) or git-init(1) will probe and set core.ignorecase true if appropriate when the repository is created.