### PR TITLE
[docker-compose] Prevent exposure of mysql db ports

### DIFF
--- a/docker-compose/docker-compose-secured.yml
+++ b/docker-compose/docker-compose-secured.yml
@@ -5,8 +5,6 @@ services:
       image: mariadb:10.0
       expose:
         - "3306"
-      ports:
-        - "3306:3306"
       environment:
         - MYSQL_ROOT_PASSWORD=
         - MYSQL_ALLOW_EMPTY_PASSWORD=yes

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       image: mariadb:10.0
       expose:
         - "3306"
-      ports:
-        - "3306:3306"
       environment:
         - MYSQL_ROOT_PASSWORD=
         - MYSQL_ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
This PR addresses https://github.com/chaoss/grimoirelab/issues/283, thus it deletes the param `ports` to prevent the exposure of mysql/mariadb ports.