### PR TITLE
[third-party] Remove param git-path from setup.cfg

### DIFF
--- a/third-party/README.md
+++ b/third-party/README.md
@@ -129,7 +129,6 @@ Copy/replace the following files in the current directory (`default-grimoirelab-
     category = code_complexity_lizard_file
     studies = [enrich_cocom_analysis]
     branches = master
-    git-path = /tmp/git-cocom
     worktree-path = /tmp/cocom/
     
     [enrich_cocom_analysis]
@@ -143,7 +142,6 @@ Copy/replace the following files in the current directory (`default-grimoirelab-
     studies = [enrich_colic_analysis]
     exec-path = /usr/share/fossology/nomos/agent/nomossa
     branches = master
-    git-path = /tmp/git-colic
     worktree-path = /tmp/colic
     
     [enrich_colic_analysis]


### PR DESCRIPTION
This code removes the param `git-path` from the example of the setup.cfg in the README. This change is due to the fact that when the git-path is set and multiple repos are defined in the projects.json, they are cloned in the same folder and their info is mixed together.

Related to https://github.com/chaoss/grimoirelab-graal/issues/86