### PR TITLE
[README] Add a picture of GrimoireLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GrimoireLab
 
+[![showcase](https://user-images.githubusercontent.com/25265451/77209811-4b544f80-6b25-11ea-954d-03855daea3c2.png "GrimoireLab | CHAOSS Bitergia Analytics")](https://chaoss.biterg.io/app/kibana#/dashboard/Overview)
+
 GrimoireLab is a [CHAOSS](https://chaoss.community) toolset for software development analytics. It includes a coordinated set of tools
 to retrieve data from systems used to support software development (repositories), store it in databases,
 enrich it by computing relevant metrics, and making it easy to run analytics and visualizations on it.


### PR DESCRIPTION
Following the discussion at https://github.com/chaoss/grimoirelab-sirmordred/pull/428#discussion_r392673442, this PR adds a picture of GrimoireLab to the README.md as a showcase.

Do you think if it would good if the picture goes above `# GrimoireLab` in the README?
