### PR TITLE
Update aliases.json and kibiter version

### DIFF
--- a/default-grimoirelab-settings/aliases.json
+++ b/default-grimoirelab-settings/aliases.json
@@ -1,154 +1,818 @@
 {
-    "askbot": {
-        "raw": ["askbot-raw"],
-        "enrich": ["askbot", "affiliations"]
-    },
-    "apache": {
-        "raw": ["apache"]
-    },
-    "bugzilla": {
-        "raw": ["bugzilla-raw"],
-        "enrich": ["bugzilla", "affiliations"]
-    },
-    "bugzillarest": {
-        "raw": ["bugzilla-raw"],
-        "enrich": ["bugzilla", "affiliations"]
-    },
-    "crates": {
-        "raw": ["crates-raw"],
-        "enrich": ["crate", "affiliations"]
-    },
-    "confluence": {
-        "raw": ["confluence-raw"],
-        "enrich": ["confluence", "affiliations"]
-    },
-    "discourse": {
-        "raw": ["discourse-raw"],
-        "enrich": ["discourse", "affiliations"]
-    },
-    "dockerhub": {
-        "raw": ["dockerhub-raw"],
-        "enrich": ["dockerhub"]
-    },
-    "functest": {
-        "raw": ["functest-raw"],
-        "enrich": ["functest"]
-    },
-    "gerrit": {
-        "raw": ["gerrit-raw"],
-        "enrich": ["gerrit", "affiliations"]
-    },
-    "git": {
-        "raw": ["git-raw"],
-        "enrich": ["git", "git_author", "git_enrich", "affiliations"]
-    },
-    "github": {
-        "raw": ["github-raw"],
-        "enrich": ["github_issues", "github_issues_enrich", "issues_closed",
-                   "issues_created", "issues_updated", "affiliations"]
-    },
-    "gitlab:issues": {
-        "raw": ["gitlab_issues-raw"],
-        "enrich": ["gitlab", "gitlab_issues", "affiliations"]
-    },
-    "gitlab:merge": {
-        "raw": ["gitlab_merge_requests-raw"],
-        "enrich": ["gitlab_merge", "gitlab_merge_requests", "affiliations"]
-    },
-    "google_hits": {
-        "raw": ["google-hits-raw"],
-        "enrich": ["google-hits"]
-    },
-    "hyperkitty": {
-        "raw": ["hyperkitty-raw"],
-        "enrich": ["mbox", "kafka", "affiliations"]
-    },
-    "groupsio": {
-        "raw": ["groupsio-raw"],
-        "enrich": ["mbox", "kafka", "affiliations"]
-    },
-    "jenkins": {
-        "raw": ["jenkins-raw"],
-        "enrich": ["jenkins"]
-    },
-    "jira": {
-        "raw": ["jira-raw"],
-        "enrich": ["jira", "jira_resolution_date", "affiliations"]
-    },
-    "kitsune": {
-        "raw": ["kitsune-raw"],
-        "enrich": ["kitsune", "affiliations"]
-    },
-    "mattermost": {
-        "raw": ["mattermost-raw"],
-        "enrich": ["mattermost", "affiliations"]
-    },
-    "mbox": {
-        "raw": ["mbox-raw"],
-        "enrich": ["mbox", "kafka", "affiliations"]
-    },
-    "mediawiki": {
-        "raw": ["mediawiki-raw"],
-        "enrich": ["mediawiki", "affiliations"]
-    },
-    "meetup": {
-        "raw": ["meetup-raw"],
-        "enrich": ["meetup", "affiliations"]
-    },
-    "mozillaclub": {
-        "raw": ["mozillaclub-raw"],
-        "enrich": ["mozillaclub", "affiliations"]
-    },
-    "nntp": {
-        "raw": ["nntp-raw"],
-        "enrich": ["mbox", "kafka", "affiliations"]
-    },
-    "phabricator": {
-        "raw": ["phabricator-raw"],
-        "enrich": ["phabricator", "maniphest", "affiliations"]
-    },
-    "pipermail": {
-        "raw": ["pipermail-raw"],
-        "enrich": ["mbox", "kafka", "affiliations"]
-    },
-    "puppetforge": {
-        "raw": ["puppetforge-raw"],
-        "enrich": ["puppetforge", "affiliations"]
-    },
-    "redmine": {
-        "raw": ["redmine-raw"],
-        "enrich": ["redmine", "affiliations"]
-    },
-    "remo": {
-        "raw": ["remo-raw"],
-        "enrich": ["remo", "remo-events", "remo-events_metadata__timestamp", "affiliations"]
-    },
-    "remo:activities": {
-        "raw": ["remo_activities-raw"],
-        "enrich": ["remo-activities", "remo-activities_metadata__timestamp", "affiliations"]
-    },
-    "rss": {
-        "raw": ["rss-raw"],
-        "enrich": ["rss", "affiliations"]
-    },
-    "slack": {
-        "raw": ["slack-raw"],
-        "enrich": ["slack", "affiliations"]
-    },
-    "stackexchange": {
-        "raw": ["stackexchange-raw"],
-        "enrich": ["stackoverflow", "affiliations"]
-    },
-    "supybot": {
-        "raw": ["supybot-raw"],
-        "enrich": ["supybot", "affiliations"]
-    },
-    "telegram": {
-        "raw": ["telegram-raw"],
-        "enrich": ["telegram", "affiliations"]
-    },
-    "twitter": {
-        "raw": ["twitter-raw"],
-        "enrich": ["twitter", "affiliations"]
-    }
+  "askbot": {
+    "raw": [
+      {
+        "alias": "askbot-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "askbot"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "apache": {
+    "raw": [
+      {
+        "alias": "apache"
+      }
+    ]
+  },
+  "bugzilla": {
+    "raw": [
+      {
+        "alias": "bugzilla-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "bugzilla"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
+  },
+  "bugzillarest": {
+    "raw": [
+      {
+        "alias": "bugzilla-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "bugzilla"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
+  },
+  "crates": {
+    "raw": [
+      {
+        "alias": "crates-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "crate"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "confluence": {
+    "raw": [
+      {
+        "alias": "confluence-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "confluence"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "discourse": {
+    "raw": [
+      {
+        "alias": "discourse-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "discourse"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "dockerhub": {
+    "raw": [
+      {
+        "alias": "dockerhub-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "dockerhub"
+      }
+    ]
+  },
+  "finosmeetings": {
+    "raw": [
+      {
+        "alias": "finosmeetings-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "finosmeetings"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "functest": {
+    "raw": [
+      {
+        "alias": "functest-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "functest"
+      }
+    ]
+  },
+  "gerrit": {
+    "raw": [
+      {
+        "alias": "gerrit-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "finosmeetings"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "git": {
+    "raw": [
+      {
+        "alias": "git-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "git"
+      },
+      {
+        "alias": "git_author"
+      },
+      {
+        "alias": "git_enrich"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "github:repo": {
+    "raw": [
+      {
+        "alias": "github_repositories-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github_repositories"
+      }
+    ]
+  },
+  "github2:issue": {
+    "raw": [
+      {
+        "alias": "github2_issues-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github2_issues"
+      },
+      {
+        "alias": "github2_pull_requests",
+        "filter": {
+          "terms": {
+            "issue_pull_request" : [
+              "true"
+            ]
+          }
+        }
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "github2:pull": {
+    "raw": [
+      {
+        "alias": "github2_pull_requests-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github2_pull_requests"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "github": {
+    "raw": [
+      {
+        "alias": "github-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github_issues"
+      },
+      {
+        "alias": "github_issues_enrich"
+      },
+      {
+        "alias": "issues_closed"
+      },
+      {
+        "alias": "issues_created"
+      },
+      {
+        "alias": "issues_updated"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets",
+        "filter" : {
+              "terms" : {
+                "pull_request" : ["false"]
+              }
+            }
+      },
+      {
+        "alias": "github_issues_onion-src",
+        "filter" : {
+            "terms" : {
+            "pull_request" : [
+                "false"
+                ]
+            }
+        }
+      },
+      {
+        "alias": "github_prs_onion-src",
+        "filter" : {
+            "terms" : {
+            "pull_request" : [
+                "true"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "gitlab:issue": {
+    "raw": [
+      {
+        "alias": "gitlab_issues-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "gitlab_issues"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
+  },
+  "gitlab:merge": {
+    "raw": [
+      {
+        "alias": "gitlab_merge_requests-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "gitlab_merge_requests"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "google_hits": {
+    "raw": [
+      {
+        "alias": "google-hits-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "google-hits"
+      }
+    ]
+  },
+  "hyperkitty": {
+    "raw": [
+      {
+        "alias": "hyperkitty-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "groupsio": {
+    "raw": [
+      {
+        "alias": "groupsio-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "jenkins": {
+    "raw": [
+      {
+        "alias": "jenkins-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "jenkins"
+      }
+    ]
+  },
+  "jira": {
+    "raw": [
+      {
+        "alias": "jira-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "jira"
+      },
+      {
+        "alias": "jira_resolution_date"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
+  },
+  "kitsune": {
+    "raw": [
+      {
+        "alias": "kitsune-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "kitsune"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "mattermost": {
+    "raw": [
+      {
+        "alias": "mattermost-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mattermost"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "mbox": {
+    "raw": [
+      {
+        "alias": "mbox-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "mediawiki": {
+    "raw": [
+      {
+        "alias": "mediawiki-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mediawiki"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "meetup": {
+    "raw": [
+      {
+        "alias": "meetup-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "meetup"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "mozillaclub": {
+    "raw": [
+      {
+        "alias": "mozillaclub-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mozillaclub"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "nntp": {
+    "raw": [
+      {
+        "alias": "mozillaclub-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "phabricator": {
+    "raw": [
+      {
+        "alias": "phabricator-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "phabricator"
+      },
+      {
+        "alias": "maniphest"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "pipermail": {
+    "raw": [
+      {
+        "alias": "pipermail-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "puppetforge": {
+    "raw": [
+      {
+        "alias": "puppetforge-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "puppetforge"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "redmine": {
+    "raw": [
+      {
+        "alias": "redmine-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "redmine"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
+  },
+  "remo": {
+    "raw": [
+      {
+        "alias": "remo-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "remo"
+      },
+      {
+        "alias": "remo-events"
+      },
+      {
+        "alias": "remo-events_metadata__timestamp"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "remo:activities": {
+    "raw": [
+      {
+        "alias": "remo_activities-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "remo-activities"
+      },
+      {
+        "alias": "remo-activities_metadata__timestamp"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "rss": {
+    "raw": [
+      {
+        "alias": "rss-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "rss"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "slack": {
+    "raw": [
+      {
+        "alias": "slack-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "slack"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "stackexchange": {
+    "raw": [
+      {
+        "alias": "stackexchange-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "stackoverflow"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "supybot": {
+    "raw": [
+      {
+        "alias": "irc-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "irc"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "telegram": {
+    "raw": [
+      {
+        "alias": "telegram-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "telegram"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "twitter": {
+    "raw": [
+      {
+        "alias": "twitter-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "twitter"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   }
+}

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
     kibiter:
       restart: on-failure:5
-      image: bitergia/kibiter:optimized-v6.1.4-4
+      image: bitergia/kibiter:optimized-v6.1.4-3
       environment:
         - PROJECT_NAME=Demo
         - NODE_OPTIONS=--max-old-space-size=1000

--- a/docker/aliases.json
+++ b/docker/aliases.json
@@ -1,15 +1,818 @@
 {
+  "askbot": {
+    "raw": [
+      {
+        "alias": "askbot-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "askbot"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "apache": {
+    "raw": [
+      {
+        "alias": "apache"
+      }
+    ]
+  },
+  "bugzilla": {
+    "raw": [
+      {
+        "alias": "bugzilla-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "bugzilla"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
+  },
+  "bugzillarest": {
+    "raw": [
+      {
+        "alias": "bugzilla-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "bugzilla"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
+  },
+  "crates": {
+    "raw": [
+      {
+        "alias": "crates-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "crate"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "confluence": {
+    "raw": [
+      {
+        "alias": "confluence-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "confluence"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "discourse": {
+    "raw": [
+      {
+        "alias": "discourse-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "discourse"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "dockerhub": {
+    "raw": [
+      {
+        "alias": "dockerhub-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "dockerhub"
+      }
+    ]
+  },
+  "finosmeetings": {
+    "raw": [
+      {
+        "alias": "finosmeetings-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "finosmeetings"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "functest": {
+    "raw": [
+      {
+        "alias": "functest-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "functest"
+      }
+    ]
+  },
+  "gerrit": {
+    "raw": [
+      {
+        "alias": "gerrit-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "finosmeetings"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
   "git": {
-      "raw": ["git-raw"],
-      "enrich": ["git", "git_author", "git_enrich", "affiliations"]
+    "raw": [
+      {
+        "alias": "git-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "git"
+      },
+      {
+        "alias": "git_author"
+      },
+      {
+        "alias": "git_enrich"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "github:repo": {
+    "raw": [
+      {
+        "alias": "github_repositories-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github_repositories"
+      }
+    ]
+  },
+  "github2:issue": {
+    "raw": [
+      {
+        "alias": "github2_issues-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github2_issues"
+      },
+      {
+        "alias": "github2_pull_requests",
+        "filter": {
+          "terms": {
+            "issue_pull_request" : [
+              "true"
+            ]
+          }
+        }
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "github2:pull": {
+    "raw": [
+      {
+        "alias": "github2_pull_requests-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github2_pull_requests"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "github": {
-      "raw": ["github-raw"],
-      "enrich": ["github_issues", "github_issues_enrich", "issues_closed",
-                 "issues_created", "issues_updated", "affiliations"]
+    "raw": [
+      {
+        "alias": "github-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github_issues"
+      },
+      {
+        "alias": "github_issues_enrich"
+      },
+      {
+        "alias": "issues_closed"
+      },
+      {
+        "alias": "issues_created"
+      },
+      {
+        "alias": "issues_updated"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets",
+        "filter" : {
+              "terms" : {
+                "pull_request" : ["false"]
+              }
+            }
+      },
+      {
+        "alias": "github_issues_onion-src",
+        "filter" : {
+            "terms" : {
+            "pull_request" : [
+                "false"
+                ]
+            }
+        }
+      },
+      {
+        "alias": "github_prs_onion-src",
+        "filter" : {
+            "terms" : {
+            "pull_request" : [
+                "true"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "gitlab:issue": {
+    "raw": [
+      {
+        "alias": "gitlab_issues-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "gitlab_issues"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
+  },
+  "gitlab:merge": {
+    "raw": [
+      {
+        "alias": "gitlab_merge_requests-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "gitlab_merge_requests"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "google_hits": {
+    "raw": [
+      {
+        "alias": "google-hits-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "google-hits"
+      }
+    ]
+  },
+  "hyperkitty": {
+    "raw": [
+      {
+        "alias": "hyperkitty-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "groupsio": {
+    "raw": [
+      {
+        "alias": "groupsio-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "jenkins": {
+    "raw": [
+      {
+        "alias": "jenkins-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "jenkins"
+      }
+    ]
+  },
+  "jira": {
+    "raw": [
+      {
+        "alias": "jira-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "jira"
+      },
+      {
+        "alias": "jira_resolution_date"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
+  },
+  "kitsune": {
+    "raw": [
+      {
+        "alias": "kitsune-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "kitsune"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "mattermost": {
+    "raw": [
+      {
+        "alias": "mattermost-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mattermost"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "mbox": {
+    "raw": [
+      {
+        "alias": "mbox-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "mediawiki": {
+    "raw": [
+      {
+        "alias": "mediawiki-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mediawiki"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "meetup": {
+    "raw": [
+      {
+        "alias": "meetup-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "meetup"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "mozillaclub": {
+    "raw": [
+      {
+        "alias": "mozillaclub-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mozillaclub"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "nntp": {
+    "raw": [
+      {
+        "alias": "mozillaclub-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "phabricator": {
+    "raw": [
+      {
+        "alias": "phabricator-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "phabricator"
+      },
+      {
+        "alias": "maniphest"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "pipermail": {
-      "raw": ["pipermail-raw"],
-      "enrich": ["mbox", "affiliations"]
+    "raw": [
+      {
+        "alias": "pipermail-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "puppetforge": {
+    "raw": [
+      {
+        "alias": "puppetforge-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "puppetforge"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "redmine": {
+    "raw": [
+      {
+        "alias": "redmine-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "redmine"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
+  },
+  "remo": {
+    "raw": [
+      {
+        "alias": "remo-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "remo"
+      },
+      {
+        "alias": "remo-events"
+      },
+      {
+        "alias": "remo-events_metadata__timestamp"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "remo:activities": {
+    "raw": [
+      {
+        "alias": "remo_activities-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "remo-activities"
+      },
+      {
+        "alias": "remo-activities_metadata__timestamp"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "rss": {
+    "raw": [
+      {
+        "alias": "rss-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "rss"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "slack": {
+    "raw": [
+      {
+        "alias": "slack-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "slack"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "stackexchange": {
+    "raw": [
+      {
+        "alias": "stackexchange-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "stackoverflow"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "supybot": {
+    "raw": [
+      {
+        "alias": "irc-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "irc"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "telegram": {
+    "raw": [
+      {
+        "alias": "telegram-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "telegram"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "twitter": {
+    "raw": [
+      {
+        "alias": "twitter-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "twitter"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This PR updates:

- the kibiter image used in the docker-compose to 6.1.4-3, since the network plugin isn't loaded in the current version.
- the aliases.json file which was changed (https://github.com/chaoss/grimoirelab-sirmordred/commit/b6fa5962bfc5dcb7cc779a71586d91c92f3a7057) to deal with complex aliases.