### PR TITLE
[docker/full-3p] update the link for fossology source

### DIFF
--- a/third-party/Dockerfile-grimoirelab-3p
+++ b/third-party/Dockerfile-grimoirelab-3p
@@ -9,18 +9,18 @@ MAINTAINER Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ADD build/fossology-common_3.6.0-1_amd64.deb /tmp
-ADD build/fossology-nomos_3.6.0-1_amd64.deb /tmp
+ADD build/fossology-common_3.0.0-1_amd64.deb /tmp
+ADD build/fossology-nomos_3.0.0-1_amd64.deb /tmp
 # install dependencies
 RUN sudo apt-get update && \
-    sudo apt-get -y install /tmp/fossology-common_3.6.0-1_amd64.deb \
-    	/tmp/fossology-nomos_3.6.0-1_amd64.deb \
+    sudo apt-get -y install /tmp/fossology-common_3.0.0-1_amd64.deb \
+    	/tmp/fossology-nomos_3.0.0-1_amd64.deb \
     	cloc \
         && \
     sudo apt-get clean && \
     sudo find /var/lib/apt/lists -type f -delete && \
-    sudo rm /tmp/fossology-common_3.6.0-1_amd64.deb \
-       /tmp/fossology-nomos_3.6.0-1_amd64.deb
+    sudo rm /tmp/fossology-common_3.0.0-1_amd64.deb \
+       /tmp/fossology-nomos_3.0.0-1_amd64.deb
 
 RUN wget https://github.com/crossminer/crossJadolint/releases/download/Pre-releasev2/jadolint.jar
 

--- a/third-party/entrypoint-fossology.sh
+++ b/third-party/entrypoint-fossology.sh
@@ -3,10 +3,10 @@
 echo "Starting container:" $(hostname)
 
 echo "Getting FOSSology source package..."
-dget -u https://mentors.debian.net/debian/pool/main/f/fossology/fossology_3.6.0-1.dsc
+dget -u http://mirrors.kernel.org/fossology/releases/3.0.0/debian/7.0/fossology_3.0.0-1.dsc
 
 echo "Building packages..."
-cd fossology-3.6.0
+cd fossology-3.0.0
 /usr/bin/debuild -us -uc
 echo "If FOSSology packages were built, look for them where you mounted /build"
 


### PR DESCRIPTION
The existing fossology source repository is deleted which is causing the build to fail (#306). This PR  updates it with the latest source link.

