### PR TITLE
[docker-compose] Use latest tag

### DIFF
--- a/docker-compose/docker-compose-secured.yml
+++ b/docker-compose/docker-compose-secured.yml
@@ -47,7 +47,7 @@ services:
 
     mordred:
       restart: on-failure:5
-      image: bitergia/mordred:grimoirelab-0.2.39
+      image: bitergia/mordred:latest
       volumes:
         - ../default-grimoirelab-settings/setup-secured.cfg:/home/bitergia/conf/setup.cfg
         - ../default-grimoirelab-settings/aliases.json:/home/bitergia/conf/aliases.json

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
     mordred:
       restart: on-failure:5
-      image: bitergia/mordred:grimoirelab-0.2.39
+      image: bitergia/mordred:latest
       volumes:
         - ../default-grimoirelab-settings/setup.cfg:/home/bitergia/conf/setup.cfg
         - ../default-grimoirelab-settings/aliases.json:/home/bitergia/conf/aliases.json


### PR DESCRIPTION
This code allows to use the latest mordred image available on dockerhub. This tag is added when
generating the release.