### PR TITLE
Making the 'How to contribute to GrimoireLab' more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,7 @@ BibTeX / BibLaTeX:
   doi = 	 {10.7717/peerj-cs.601},
   url = 	 {https://doi.org/10.7717/peerj-cs.601}}
 ```
+
+# Contributing
+
+Contributions are welcome, please check the [Contributing Guidelines](CONTRIBUTING.md).

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -10,6 +10,7 @@
                     <a class="text-white" href="https://join.slack.com/t/chaoss-workspace/shared_invite/zt-r65szij9-QajX59hkZUct82b0uACA6g">CHAOSS Slack</a> or 
                     <a class="text-white" href="https://lists.linuxfoundation.org/mailman/listinfo/grimoirelab-discussions">GrimoireLab mailing list</a> 
                     to get in touch with the <em>community</em>.</p>
+                    <p class="text-justify">Please check the <a href="https://github.com/chaoss/grimoirelab/blob/master/CONTRIBUTING.md">Contribution Guidelines</a>.</p>
             </div>
             <div class="footer-col col-md-6">
                 <h3>Join us!</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,8 +41,8 @@ sections:
         <svg class="bi bi-terminal-fill h2" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" d="M0 3a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H2a2 2 0 01-2-2V3zm9.5 5.5h-3a.5.5 0 000 1h3a.5.5 0 000-1zm-6.354-.354L4.793 6.5 3.146 4.854a.5.5 0 11.708-.708l2 2a.5.5 0 010 .708l-2 2a.5.5 0 01-.708-.708z" clip-rule="evenodd"/>
         </svg>
-         Start here!</a>
-  </div>
+      Start here!</a>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
- Updated the README.md file to also contain the link to the contributing guidelines (CONTRIBUTING.md)
- Updated the landing page for GrimoireLab to display the link to the Contributing Guidelines, since the website did not mention them anywhere. 
This can increase the ease and accessibility with which users may refer to the guidelines.

Resolved issue: [#342](https://github.com/chaoss/grimoirelab/issues/342)