### PR TITLE
Added file-descriptor limit in elasticsearch service configuration

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       command: elasticsearch -Enetwork.bind_host=0.0.0.0 -Ehttp.max_content_length=2000mb
       ports:
         - 9200:9200
+      ulimits:
+        nofile:
+          soft: "65536"
+          hard: "65536"
       environment:
         - ES_JAVA_OPTS=-Xms2g -Xmx2g
         - ANONYMOUS_USER=true


### PR DESCRIPTION
Fix for https://github.com/chaoss/grimoirelab/issues/394 

Deployment using docker-compose as per instructions from https://github.com/chaoss/grimoirelab#using-docker-compose is failing due to file-descriptor settings. Added file-descriptor limit.

