### PR TITLE
Add discourse example in setup.cfg

### DIFF
--- a/default-grimoirelab-settings/setup.cfg
+++ b/default-grimoirelab-settings/setup.cfg
@@ -57,6 +57,11 @@ panels = true
 #raw_index = confluence_demo_raw
 #enriched_index = confluence_demo_enriched
 
+#[discourse]
+#raw_index = discourse_demo_raw
+#enriched_index = discourse_demo_enriched
+#no-archive = true
+
 [git]
 raw_index = git_demo_raw
 enriched_index = git_demo_enriched


### PR DESCRIPTION
# Overview

As per other data sources, it may be useful for newcomers to have a commented out configuration for the discourse backend.

This configuration information was given in [issue #132 of grimoirelab-tutorial](https://github.com/chaoss/grimoirelab-tutorial/issues/132)