### PR TITLE
Add Cauldron stats to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Metrics available in GrimoireLab are, in part, developed in the CHAOSS project. 
 
 ## Community activity
 
-![Cauldron.io stats for GrimoireLab](https://cauldron.io/project/2641/stats.svg)
+<img alt="Cauldron.io stats for GrimoireLab" src="https://cauldron.io/project/2641/stats.svg" width="400" />
 
 # Getting started
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ or visit the [GrimoireLab website](https://chaoss.github.io/grimoirelab).
 
 Metrics available in GrimoireLab are, in part, developed in the CHAOSS project. For more information regarding CHAOSS metrics, see the latest release at: https://chaoss.community/metrics/
 
+## Community activity
+
+![Cauldron.io stats for GrimoireLab](https://cauldron.io/project/2641/stats.svg)
+
 # Getting started
 
 GrimoireLab is a set of tools, and to ease starting playing we are providing a [default setup](default-grimoirelab-settings)


### PR DESCRIPTION
First GitHub repo to use the latest Cauldron release feature
to include an image with updated stats in their README.