### PR TITLE
Replace IRC links with Slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ GrimoireLab is a part of the [Software Technical Committee](https://wiki.linuxfo
 GrimoireLab  use the following communication channels:
 
 * Mailing list
-* IRC channel
+* Slack
 * Issues / pull requests
 
 Each of them is intended for an specific purpose. Please understand
@@ -32,11 +32,12 @@ in other communication means.
 * Questions and community support that really don't fit in other
 communication means.
 
-### IRC channel
+### Slack
 
-Channel: `#grimoirelab` at [Freenode](http://freenode.net/)
+Channel: [`#grimoirelab`](https://chaoss-workspace.slack.com/archives/C022NPTPC8Z) 
+at [CHAOSS Slack](https://join.slack.com/t/chaoss-workspace/shared_invite/zt-r65szij9-QajX59hkZUct82b0uACA6g)
 
-We use the channel for pinging people, quick and informal
+We use the channel for pinging people, sharing updates, quick and informal
 discussions, questions and answers, etc. Please, don't consider that
 developers in the channel will be always available, or always willing
 to answer questions and comments. However, anyone interested in the

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -6,8 +6,8 @@
                 <h3>Community contact</h3>
                 <p class="text-justify">Feel free to post issues or open pull requests in any of the GrimoireLab repositories (listed in the 
                     <a class="text-white" href="http://github.com/chaoss/grimoirelab">chaoss/grimoirelab GitHub repository</a>, or join 
-                    <a class="text-white" href="http://webchat.freenode.net/?channels=GrimoireLab"><code>#GrimoireLab</code></a> IRC channel in 
-                    <a class="text-white" href="https://freenode.net/">Freenode</a> or 
+                    <a class="text-white" href="https://chaoss-workspace.slack.com/archives/C022NPTPC8Z"><code>#grimoireLab</code></a> channel in 
+                    <a class="text-white" href="https://join.slack.com/t/chaoss-workspace/shared_invite/zt-r65szij9-QajX59hkZUct82b0uACA6g">CHAOSS Slack</a> or 
                     <a class="text-white" href="https://lists.linuxfoundation.org/mailman/listinfo/grimoirelab-discussions">GrimoireLab mailing list</a> 
                     to get in touch with the <em>community</em>.</p>
             </div>
@@ -16,7 +16,7 @@
                 <ul class="list-inline">
                     <li class="list-inline-item"><a class="text-white btn-social btn-outline" href="http://github.com/chaoss/grimoirelab"><i data-feather="github"></i></a></li>
                     <li class="list-inline-item"><a class="text-white btn-social btn-outline" href="https://lists.linuxfoundation.org/mailman/listinfo/grimoirelab-discussions"><i data-feather="mail"></i></a></li>
-                    <li class="list-inline-item"><a class="text-white btn-social btn-outline" href="http://webchat.freenode.net/?channels=GrimoireLab"><i data-feather="message-square"></i></a></li>
+                    <li class="list-inline-item"><a class="text-white btn-social btn-outline" href="https://chaoss-workspace.slack.com/archives/C022NPTPC8Z"><i data-feather="slack"></i></a></li>
                 </ul>
                 <a href="http://chaoss.community"><img src="{{site.baseurl}}/img/Chaoss_Logo_Pantone2.png" alt="CHAOSS: Community Health Analytics for Open Source Software" height="32"></a>
             </div>


### PR DESCRIPTION
This PR replaces the IRC chat links with the slack group. We want to use slack for communication and need this change on the website and CONTRIBUTING.md docs.

Closes https://github.com/chaoss/grimoirelab/issues/431