### PR TITLE
[release] Wait for packages ready in PyPI before continuing

### DIFF
--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -254,6 +254,20 @@ jobs:
             fi
           done
 
+      - id: check-package-ready
+        name: Wait for package ready in PyPI
+        shell: bash
+        if: steps.wait-for-release.outcome == 'success'
+        run: |
+          package="${{ inputs.module_name }}==${{ steps.version.outputs.version }}"
+
+          while true
+          do
+            pip install $package && break
+            sleep 10
+            echo "Wait..."
+          done
+
       - id: rollback
         name: Rollback last commit and remove tag
         if: steps.wait-for-release.outcome == 'failure'


### PR DESCRIPTION
This PR includes a new step in the package release. When the release finishes, it waits until the package is ready in PyPI.
- One example that continues: https://github.com/jjmerchante2/grimoirelab/runs/8227716278?check_suite_focus=true#step:12:1
- Another example that keeps waiting and canceled manually: https://github.com/jjmerchante2/grimoirelab/runs/8227858527?check_suite_focus=true#step:12:1