### PR TITLE
[release] Update a bug in the 'pip index version'

### DIFF
--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -270,7 +270,8 @@ jobs:
           pip install --upgrade pip
           for i in $(seq 20)
           do
-            pipVersion=$(pip index versions --pre $package 2>/dev/null | head -n 1 | cut -f2 -d '(' | cut -f1 -d ')')
+            pip index versions --pre $package > pip_versions.txt
+            pipVersion=$(cat pip_versions.txt | head -n 1 | cut -f2 -d '(' | cut -f1 -d ')')
             echo "$currentVersion $pipVersion"
             if [ "$pipVersion" = "$currentVersion" ]
             then


### PR DESCRIPTION
This commit stores the output of `pip index version` in a file instead of redirecting the output to a pipe because it seems not to be allowed.

https://github.com/jjmerchante2/grimoirelab/runs/8273848644?check_suite_focus=true#step:12:1