### PR TITLE
[release] Poetry no cache exponential retry

### DIFF
--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -105,10 +105,12 @@ jobs:
           dependencies="${{ inputs.dependencies }}"
           if [ ! -z "$dependencies" ]
           then
-            for i in $(seq 10)
+            timeout=5
+            for i in $(seq 5)
             do
-              poetry add --lock --dry-run $dependencies && exit 0
-              sleep 10
+              poetry add --lock --no-cache --dry-run $dependencies && exit 0
+              sleep $timeout
+              timeout=$(( timeout * 2 ))
             done
             exit 1
           fi


### PR DESCRIPTION
This PR updates Poetry's command that checks for new versions including --no-cache in case it is taking the latest version from the cache and changing the retry to exponential backoff.
