### PR TITLE
[release] Fix workflow triggering from another workflow

### DIFF
--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -338,6 +338,8 @@ jobs:
       - grimoirelab-sirmordred
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: '${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}'
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
@@ -348,10 +350,6 @@ jobs:
         run: |
           git config --global user.email "${{ inputs.git_email }}"
           git config --global user.name "${{ inputs.git_name }}"
-
-      - name: Configure repository credentials
-        run: |
-          git remote set-url origin https://${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}@github.com/chaoss/grimoirelab.git
 
       - name: Install poetry
         run: |


### PR DESCRIPTION
This PR fixes an issue that didn't allow triggering the `release.yml` workflow from `grimoirelab-release.yml` when creating a new tag from the same repository.

`actions/checkout` allows to include a token variable that by default is `github.token` and is persisted in the local git config, which makes that defining the token in any other way doesn't use it.

The default `github.token` prevents you from accidentally creating workflow runs, that's why it didn't trigger a new
workflow when it creates a new tag.

Closes https://github.com/chaoss/grimoirelab/issues/525