### PR TITLE
[docker] Include docker-compose with OpenSearch image

### DIFF
--- a/default-grimoirelab-settings/setup-opensearch.cfg
+++ b/default-grimoirelab-settings/setup-opensearch.cfg
@@ -1,0 +1,155 @@
+[general]
+short_name = GrimoireLab
+update = true
+min_update_delay = 60
+debug = false
+logs_dir = /home/grimoire/logs
+bulk_size = 1000
+scroll_size = 1000
+aliases_file = /home/grimoire/aliases.json
+
+[projects]
+projects_file = /home/grimoire/conf/projects.json
+
+[es_collection]
+url = https://admin:admin@opensearch-node1:9200
+
+[es_enrichment]
+url = https://admin:admin@opensearch-node1:9200
+autorefresh = true
+
+[sortinghat]
+host = mariadb
+user = root
+password =
+database = demo_sh
+load_orgs = true
+orgs_file = /home/grimoire/organizations.json
+autoprofile = [github, pipermail, git]
+matching = [email,username]
+sleep_for = 100
+unaffiliated_group = Unknown
+affiliate = true
+strict_mapping = false
+reset_on_load = false
+identities_file = [/home/grimoire/conf/identities.yml]
+identities_format = grimoirelab
+
+[panels]
+kibiter_time_from = now-5y
+kibiter_default_index = git
+kibiter_url = http://admin:admin@opensearch-dashboards:5601
+gitlab-issues = true
+gitlab-merges = true
+
+[phases]
+collection = true
+identities = true
+enrichment = true
+panels = false
+
+#[bugzillarest]
+#raw_index = bugzillarest_demo_raw
+#enriched_index = bugzillarest_demo_enriched
+#no-archive = true
+
+#[confluence]
+#no-archive = true
+#raw_index = confluence_demo_raw
+#enriched_index = confluence_demo_enriched
+
+#[discourse]
+#raw_index = discourse_demo_raw
+#enriched_index = discourse_demo_enriched
+#no-archive = true
+
+[git]
+raw_index = git_demo_raw
+enriched_index = git_demo_enriched
+latest-items = true
+studies = [enrich_demography:git, enrich_areas_of_code:git, enrich_onion:git]
+
+#[github]
+#api-token = <YOUR_API_TOKEN_WHERE>
+#enterprise-url = <YOUR_GITHUB_ENTERPRISE_URL>
+#raw_index = github_demo_raw
+#sleep-for-rate = true
+#sleep-time = "300"
+#enriched_index = github_demo_enriched
+
+#[gitlab:issues]
+#api-token = <YOUR_API_TOKEN_HERE>
+#raw_index = gitlab_issues_demo_raw
+#enriched_index = gitlab_issues_demo_enriched
+#no-archive = true
+#enterprise-url = <YOUR_GITLAB_INSTANCE_URL>
+#sleep-for-rate = true
+
+#[gitlab:merge]
+#api-token = <YOUR_API_TOKEN_HERE>
+#raw_index = gitlab_merges_demo_raw
+#enriched_index = gitlab_merges_demo_enriched
+#no-archive = true
+#enterprise-url = <YOUR_GITLAB_INSTANCE_URL>
+#category = merge_request
+#sleep-for-rate = true
+
+#[jira]
+#raw_index = jira_demo_raw
+#enriched_index = jira_demo_enriched
+#no-archive = true
+
+#[pipermail]
+#raw_index = pipermail_demo_raw
+#enriched_index = pipermail_demo_enriched
+#no-verify = true
+
+#[mediawiki]
+#raw_index = mediawiki_demo_raw
+#enriched_index = mediawiki_demo_enriched
+#no-archive = true
+
+#[meetup]
+#raw_index = meetup_demo_raw
+#enriched_index = meetup_demo_enriched
+#api-token = <YOUR_API_TOKEN_WHERE>
+#no-archive = true
+#sleep-for-rate = true
+#sleep-time = "300"
+
+#[stackexchange]
+#raw_index = stackexchange_demo_raw
+#enriched_index = stackexchange_demo_enriched
+#api-token = <YOUR_API_TOKEN_WHERE>
+#no-archive = true
+
+#[slack]
+#raw_index = slack_demo_raw
+#enriched_index = slack_demo_enriched
+#api-token = <YOUR_API_TOKEN_WHERE>
+#no-archive = true
+
+#[supybot]
+#raw_index = supybot_demo_raw
+#enriched_index = supybot_demo_enriched
+
+#[twitter]
+#raw_index = twitter_demo_raw
+#enriched_index = twitter_demo_enriched
+#api-token = <YOUR_API_TOKEN_WHERE>
+#no-archive = true
+#sleep-for-rate = true
+#sleep-time = 300
+
+## studies based on enriched indexes
+
+[enrich_demography:git]
+
+[enrich_areas_of_code:git]
+in_index = git_demo_raw
+out_index = git-aoc_demo_enriched
+
+[enrich_onion:git]
+in_index = git
+out_index = git-onion_demo_enriched
+contribs_field = hash

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -100,6 +100,30 @@ asked to login.
 
 To change them, you need to enter in `elasticsearch` container and change [SearchGuard plugin](https://search-guard.com/) parameters.
 
+## Opensearch
+
+OpenSearch is an Open Source fork of Elasticsearch that includes additional
+features and plugins. It has its own security plugin for authentication and
+access control.
+
+GrimoireLab works with OpenSearch, but panels are not automatically created,
+but they can be manually imported.
+
+If you want to deploy this infrastructure with minimal security, use the
+`docker-compose-opensearch.yml` file:
+
+```
+docker-compose -f docker-compose-opensearch.yml up -d
+```
+
+To access to the dashboard would be the same as previously, but you would be
+asked to log in:
+* User: `admin`
+* Password: `admin`
+
+For more information related with OpenSearch: https://opensearch.org/docs/latest/
+
+
 # More information
 
 * [The `projects.json` file format](https://github.com/chaoss/grimoirelab-sirmordred#projectsjson-)

--- a/docker-compose/docker-compose-opensearch.yml
+++ b/docker-compose/docker-compose-opensearch.yml
@@ -1,0 +1,68 @@
+version: '2.2'
+
+services:
+    mariadb:
+      image: mariadb:10.6
+      expose:
+        - "3306"
+      environment:
+        - MYSQL_ROOT_PASSWORD=
+        - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+
+    hatstall:
+      image: grimoirelab/hatstall:latest
+      environment:
+        - DATABASE_DIR=/db/
+        - ADMIN_USER=admin
+        - ADMIN_PASS=admin
+      ports:
+        - 8000:80
+      links:
+        - mariadb
+      volumes:
+        - ../default-grimoirelab-settings/apache-hatstall.conf:/home/grimoirelab/apache-hatstall.conf
+        - ../default-grimoirelab-settings/shdb.cfg:/home/grimoirelab/shdb.cfg
+
+    opensearch-node1:
+      image: opensearchproject/opensearch:1.3.6
+      container_name: opensearch-node1
+      environment:
+        - cluster.name=opensearch-cluster
+        - node.name=opensearch-node1
+        - discovery.type=single-node
+        - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+        - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
+        nofile:
+          soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+          hard: 65536
+      ports:
+        - 9200:9200
+        - 9600:9600 # required for Performance Analyzer
+
+    opensearch-dashboards:
+      image: opensearchproject/opensearch-dashboards:1.3.6
+      container_name: opensearch-dashboards
+      ports:
+        - 5601:5601
+      expose:
+        - "5601"
+      environment:
+        OPENSEARCH_HOSTS: '["https://opensearch-node1:9200"]'
+
+    mordred:
+      restart: on-failure:5
+      image: grimoirelab/grimoirelab:latest
+      volumes:
+        - ../default-grimoirelab-settings/setup-opensearch.cfg:/home/grimoire/conf/setup.cfg
+        - ../default-grimoirelab-settings/projects.json:/home/grimoire/conf/projects.json
+        - ../default-grimoirelab-settings/organizations.json:/home/grimoire/organizations.json
+        - ../default-grimoirelab-settings/identities.yml:/home/grimoire/conf/identities.yml
+        - /tmp/:/home/grimoire/logs
+      depends_on:
+        - mariadb
+        - opensearch-node1
+      mem_limit: 4g


### PR DESCRIPTION
This PR includes a new docker-compose to run GrimoireLab using the official OpenSearch image.

GrimoireLab doesn't execute the panels phase because Sigils doesn't work with Elastic versions newer than 6.8.

Closes https://github.com/chaoss/grimoirelab/issues/526
