### PR TITLE
[release] Update GrimoireLab version and include --pre-release to notes

### DIFF
--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -359,7 +359,7 @@ jobs:
       - id: check-dependencies
         name: Check if package dependencies exist
         run: |
-          sleep 60
+          sleep 180
 
       - id: semverup
         name: Update version number

--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -362,31 +362,82 @@ jobs:
 
       - id: semverup
         name: Update version number
+        env:
+          grimoirelab_toolkit_version: "${{ needs.grimoirelab-toolkit.outputs.version}}"
+          kidash_version: "${{ needs.grimoirelab-kidash.outputs.version}}"
+          sortinghat_version: "${{ needs.grimoirelab-sortinghat.outputs.version}}"
+          cereslib_version: "${{ needs.grimoirelab-cereslib.outputs.version}}"
+          grimoirelab_panels_version: "${{ needs.grimoirelab-sigils.outputs.version}}"
+          perceval_version: "${{ needs.grimoirelab-perceval.outputs.version}}"
+          perceval_mozilla_version: "${{ needs.grimoirelab-perceval-mozilla.outputs.version}}"
+          perceval_opnfv_version: "${{ needs.grimoirelab-perceval-opnfv.outputs.version}}"
+          perceval_puppet_version: "${{ needs.grimoirelab-perceval-puppet.outputs.version}}"
+          perceval_weblate_version: "${{ needs.grimoirelab-perceval-weblate.outputs.version}}"
+          graal_version: "${{ needs.grimoirelab-graal.outputs.version}}"
+          grimoire_elk_version: "${{ needs.grimoirelab-elk.outputs.version}}"
+          sirmordred_version: "${{ needs.grimoirelab-sirmordred.outputs.version}}"
         run: |
-          # Check what version to update: patch, minor or major
           BUMP_MAJOR=4
           BUMP_MINOR=2
-          if [ ${{ inputs.release_candidate }} == 'true' ]
-          then
-            rcArg='--pre-release'
-          else
-            rcArg=''
-          fi
-          versionUpdated=$((
-          ${{ needs.grimoirelab-toolkit.outputs.changed_version }} |
-          ${{ needs.grimoirelab-perceval.outputs.changed_version }} |
-          ${{ needs.grimoirelab-perceval-mozilla.outputs.changed_version }} |
-          ${{ needs.grimoirelab-perceval-opnfv.outputs.changed_version }} |
-          ${{ needs.grimoirelab-perceval-puppet.outputs.changed_version }} |
-          ${{ needs.grimoirelab-perceval-weblate.outputs.changed_version }} |
-          ${{ needs.grimoirelab-elk.outputs.changed_version }} |
-          ${{ needs.grimoirelab-sortinghat.outputs.changed_version }} |
-          ${{ needs.grimoirelab-kidash.outputs.changed_version }} |
-          ${{ needs.grimoirelab-sigils.outputs.changed_version }} |
-          ${{ needs.grimoirelab-sirmordred.outputs.changed_version }} |
-          ${{ needs.grimoirelab-cereslib.outputs.changed_version }} |
-          ${{ needs.grimoirelab-graal.outputs.changed_version }}))
-
+          BUMP_PATCH=1
+          NO_BUMP=0
+          
+          function cmp_version () {
+            old=$1
+            old=${old%-*}
+            old=${old%rc*}
+            current=$2
+            current=${current%-*}
+            current=${current%rc*}
+            
+            currentArr=(${current//./ })
+            oldArr=(${old//./ })
+            
+            if [ ${currentArr[0]} -gt ${oldArr[0]} ]
+            then
+              echo $BUMP_MAJOR
+            elif [ ${currentArr[1]} -gt ${oldArr[1]} ]
+            then
+              echo $BUMP_MINOR
+            elif [ ${currentArr[2]} -gt ${oldArr[2]} ]
+            then
+              echo $BUMP_PATCH
+            else
+              echo $NO_BUMP
+            fi
+          }
+          
+          function old_pkg_version () {
+            pkg=$1
+            poetry show -l $pkg | grep version | head -1 | awk '{print $3}'
+          }
+          
+          pkgs=("grimoirelab-toolkit"
+          "kidash"
+          "sortinghat"
+          "cereslib"
+          "perceval"
+          "perceval-mozilla"
+          "perceval-opnfv"
+          "perceval-puppet"
+          "perceval-weblate"
+          "graal"
+          "grimoire-elk"
+          "sirmordred")
+          
+          versionUpdated=0
+          for pkg in "${pkgs[@]}"
+          do
+            pkg_ver="${pkg/-/_}_version"
+            current=${!pkg_ver}
+            old=$(old_pkg_version "$pkg")
+            output=$(cmp_version "$old" "$current")
+            echo "$pkg updated from $old to $current, changed: $output"
+            versionUpdated=$(( versionUpdated | output ))
+          done
+          
+          echo $versionUpdated
+          
           if [ $((versionUpdated & $BUMP_MAJOR )) -ne 0 ]
           then
             version=$(semverup --bump-version=major $rcArg)

--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -71,6 +71,7 @@ jobs:
     name: Sortinghat
     needs:
       - variables-job
+      - grimoirelab-toolkit
     uses: ./.github/workflows/release-grimoirelab-component.yml
     with:
       git_email: ${{ needs.variables-job.outputs.git_email }}
@@ -79,8 +80,8 @@ jobs:
       module_name: 'sortinghat'
       module_repository: 'chaoss/grimoirelab-sortinghat'
       module_directory: 'src/grimoirelab-sortinghat'
-      dependencies: ''
-      wait_dependencies: false
+      dependencies: '${{ needs.grimoirelab-toolkit.outputs.package_version }}'
+      wait_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 

--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -191,13 +191,15 @@ jobs:
           if [ ${{ inputs.release_candidate }} == 'true' ]
           then
             newsArg=''
+            rcArg='--pre-release'
           else
             newsArg='--news'
+            rcArg=''
           fi
           
           if [ ${{ steps.semverup.outputs.forced_version }} != 'true' ]
           then
-            notes "${{ inputs.module_name }}" $version $newsArg --authors   
+            notes "${{ inputs.module_name }}" $version $newsArg --authors $rcArg
           else
             module_name=${{ inputs.module_name }}
             today=$(date -u "+%Y-%m-%d")

--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -123,7 +123,7 @@ jobs:
         name: Wait for dependencies to be ready in PyPI
         if: inputs.wait_dependencies == false
         run: |
-          sleep 60
+          sleep 180
 
       - id: update-dependencies
         name: Update package dependencies

--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -51,9 +51,6 @@ on:
       notes:
         description: "Notes content for the package"
         value: ${{ jobs.release.outputs.notes }}
-      changed_version:
-        description: "The version changed was major (4), minor (2), patch (1) or not changed (0)"
-        value: ${{ jobs.release.outputs.changed_version }}
 
 jobs:
   release:
@@ -63,7 +60,6 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       package_version: ${{ steps.version.outputs.package_version }}
       notes: ${{ steps.notes.outputs.notes }}
-      changed_version: ${{ steps.changed-version.outputs.changed }}
 
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
@@ -184,36 +180,6 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
           echo $package_version
         working-directory: ${{ inputs.module_directory }}
-
-      - id: changed-version
-        name: Get the version changed
-        run: |
-          BUMP_MAJOR=4
-          BUMP_MINOR=2
-          BUMP_PATCH=1
-          current=${{ steps.version.outputs.version }}
-          old=${{ steps.old-version.outputs.version }}
-          # Remove rc part
-          current=${current%-*}
-          old=${old%-*}
-          currentArr=(${current//./ })
-          oldArr=(${old//./ })
-          if [ ${currentArr[0]} -gt ${oldArr[0]} ]
-          then
-            echo "changed=$BUMP_MAJOR" >> $GITHUB_OUTPUT
-            echo "Major"
-          elif [ ${currentArr[1]} -gt ${oldArr[1]} ]
-          then
-            echo "changed=$BUMP_MINOR" >> $GITHUB_OUTPUT
-            echo "Minor"
-          elif [ ${currentArr[2]} -gt ${oldArr[2]} ]
-          then
-            echo "changed=$BUMP_PATCH" >> $GITHUB_OUTPUT
-            echo "Patch"
-          else
-            echo "changed=0" >> $GITHUB_OUTPUT
-            echo "Not changed"
-          fi
 
       - id: notes
         name: Generate release notes.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && \
         python3-dev \
         python3-gdbm \
         mariadb-client \
+        libmariadbclient-dev-compat \
         unzip curl wget sudo ssh \
         && \
     apt-get clean && \


### PR DESCRIPTION
This PR updates how the release workflow checks the new version number for GrimoireLab.
Each package indicated the version changed in the previous version, but that method isn't idempotent when the workflow is
restarted.
Now is the last step when the version is calculated based on the packages installed in GrimoireLab and the new version for each package.

This PR also includes the `--pre-release` argument to `notes` when it is a release candidate version to execute that command according to the new changes in `release-tools`.

_Depends on `release-tools` Pull Request._