### PR TITLE
[release] Wait for Poetry packages in GitHub workflow

### DIFF
--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -46,6 +46,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-toolkit'
       module_directory: 'src/grimoirelab-toolkit'
       dependencies: ''
+      wait_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -62,6 +63,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-kidash'
       module_directory: 'src/grimoirelab-kidash'
       dependencies: ''
+      wait_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -78,6 +80,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-sortinghat'
       module_directory: 'src/grimoirelab-sortinghat'
       dependencies: ''
+      wait_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -95,6 +98,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-cereslib'
       module_directory: 'src/grimoirelab-cereslib'
       dependencies: '${{ needs.grimoirelab-toolkit.outputs.package_version }}'
+      wait_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -111,6 +115,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-sigils'
       module_directory: 'src/grimoirelab-sigils'
       dependencies: ''
+      wait_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -128,6 +133,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-perceval'
       module_directory: 'src/grimoirelab-perceval'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }}"
+      wait_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -147,6 +153,7 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-mozilla'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
+      wait_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -166,6 +173,7 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-opnfv'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
+      wait_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -185,6 +193,7 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-puppet'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
+      wait_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -204,6 +213,7 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-weblate'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
+      wait_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -223,6 +233,7 @@ jobs:
       module_directory: 'src/grimoirelab-graal'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
+      wait_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -256,6 +267,7 @@ jobs:
       ${{ needs.grimoirelab-perceval-weblate.outputs.package_version }} \
       ${{ needs.grimoirelab-graal.outputs.package_version }} \
       ${{ needs.grimoirelab-sortinghat.outputs.package_version }}"
+      wait_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -295,6 +307,7 @@ jobs:
       ${{ needs.grimoirelab-perceval-weblate.outputs.package_version }} \
       ${{ needs.grimoirelab-graal.outputs.package_version }} \
       ${{ needs.grimoirelab-cereslib.outputs.package_version }}"
+      wait_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 

--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -31,6 +31,11 @@ on:
         description: 'Package dependencies and their version'
         type: string
         required: true
+      wait_dependencies:
+        description: 'Wait until packages are ready for Poetry'
+        type: boolean
+        default: true
+        required: false
     secrets:
       access_token:
         description: 'Token for updating repositories'
@@ -100,8 +105,27 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
         working-directory: ${{ inputs.module_directory }}
 
+      - id: wait-dependencies
+        name: Check is package dependencies are ready
+        if: inputs.wait_dependencies == true
+        run: |
+          dependencies="${{ inputs.dependencies }}"
+          if [ ! -z "$dependencies" ]
+          then
+            timeout=5
+            for i in $(seq 5)
+            do
+              poetry add --lock --no-cache --dry-run $dependencies && exit 0
+              sleep $timeout
+              timeout=$(( timeout * 2 ))
+            done
+            exit 1
+          fi
+        working-directory: ${{ inputs.module_directory }}
+
       - id: wait-pypi
         name: Wait for dependencies to be ready in PyPI
+        if: inputs.wait_dependencies == false
         run: |
           sleep 60
 


### PR DESCRIPTION
This PR updates the way the release workflow waits for the dependencies. For all the repositories it waits until dependencies are ready except for ELK and Sirmordred that Poetry spends 1 hour to check if all the dependencies are ready and are substituted with 60 seconds.
