### PR TITLE
[release] Fix release candidate bug and wait for release

### DIFF
--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -46,7 +46,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-toolkit'
       module_directory: 'src/grimoirelab-toolkit'
       dependencies: ''
-      wait_dependencies: false
+      check_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -63,7 +63,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-kidash'
       module_directory: 'src/grimoirelab-kidash'
       dependencies: ''
-      wait_dependencies: false
+      check_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -81,7 +81,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-sortinghat'
       module_directory: 'src/grimoirelab-sortinghat'
       dependencies: '${{ needs.grimoirelab-toolkit.outputs.package_version }}'
-      wait_dependencies: true
+      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -99,7 +99,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-cereslib'
       module_directory: 'src/grimoirelab-cereslib'
       dependencies: '${{ needs.grimoirelab-toolkit.outputs.package_version }}'
-      wait_dependencies: true
+      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -116,7 +116,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-sigils'
       module_directory: 'src/grimoirelab-sigils'
       dependencies: ''
-      wait_dependencies: true
+      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -134,7 +134,7 @@ jobs:
       module_repository: 'chaoss/grimoirelab-perceval'
       module_directory: 'src/grimoirelab-perceval'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }}"
-      wait_dependencies: true
+      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -154,7 +154,7 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-mozilla'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-      wait_dependencies: true
+      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -174,7 +174,7 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-opnfv'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-      wait_dependencies: true
+      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -194,7 +194,7 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-puppet'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-      wait_dependencies: true
+      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -214,7 +214,7 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-weblate'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-      wait_dependencies: true
+      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -234,7 +234,7 @@ jobs:
       module_directory: 'src/grimoirelab-graal'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-      wait_dependencies: true
+      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -268,7 +268,7 @@ jobs:
       ${{ needs.grimoirelab-perceval-weblate.outputs.package_version }} \
       ${{ needs.grimoirelab-graal.outputs.package_version }} \
       ${{ needs.grimoirelab-sortinghat.outputs.package_version }}"
-      wait_dependencies: false
+      check_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -308,7 +308,7 @@ jobs:
       ${{ needs.grimoirelab-perceval-weblate.outputs.package_version }} \
       ${{ needs.grimoirelab-graal.outputs.package_version }} \
       ${{ needs.grimoirelab-cereslib.outputs.package_version }}"
-      wait_dependencies: false
+      check_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -417,6 +417,7 @@ jobs:
           "kidash"
           "sortinghat"
           "cereslib"
+          "grimoirelab-panels"
           "perceval"
           "perceval-mozilla"
           "perceval-opnfv"
@@ -425,6 +426,13 @@ jobs:
           "graal"
           "grimoire-elk"
           "sirmordred")
+          
+          if [ ${{ inputs.release_candidate }} == 'true' ]
+          then
+            rcArg='--pre-release'
+          else
+            rcArg=''
+          fi
           
           versionUpdated=0
           for pkg in "${pkgs[@]}"

--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -31,8 +31,8 @@ on:
         description: 'Package dependencies and their version'
         type: string
         required: true
-      wait_dependencies:
-        description: 'Wait until packages are ready for Poetry'
+      check_dependencies:
+        description: 'Check dependencies are available. If false and has dependencies, wait 180 seconds'
         type: boolean
         default: true
         required: false
@@ -101,9 +101,9 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
         working-directory: ${{ inputs.module_directory }}
 
-      - id: wait-dependencies
+      - id: check-dependencies
         name: Check is package dependencies are ready
-        if: inputs.wait_dependencies == true
+        if: inputs.check_dependencies == true
         run: |
           dependencies="${{ inputs.dependencies }}"
           if [ ! -z "$dependencies" ]
@@ -121,7 +121,7 @@ jobs:
 
       - id: wait-pypi
         name: Wait for dependencies to be ready in PyPI
-        if: inputs.wait_dependencies == false
+        if: (inputs.check_dependencies == false) && (inputs.dependencies != '')
         run: |
           sleep 180
 


### PR DESCRIPTION
This PR fixes the semverup command that didn't have the argument for the release candidate.

It also removes the 180 seconds wait time for packages that haven't got dependencies.

Include `grimoirelab-panels` in the version comparison check.
