### PR TITLE
[ci] Clear Poetry cache instead of running with `--no-cache`

### DIFF
--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -108,10 +108,17 @@ jobs:
           dependencies="${{ inputs.dependencies }}"
           if [ ! -z "$dependencies" ]
           then
+            clear_cache() {
+              for cache in $(poetry cache list); do
+                echo "Clear $cache"
+                poetry -n cache clear $cache --all
+              done
+            }
             timeout=5
             for i in $(seq 5)
             do
-              poetry add --lock --no-cache --dry-run $dependencies && exit 0
+              clear_cache
+              poetry add --lock --dry-run $dependencies && exit 0
               sleep $timeout
               timeout=$(( timeout * 2 ))
             done


### PR DESCRIPTION
This PR substitutes the poetry command to check if the packages are available to speed up the process.

Is much faster to clear the Poetry cache and run a command than running it with `--no-cache`.