### PR TITLE
[ci] Update deprecated ubuntu-18.04 of GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
   tests:
     needs: [build]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     name: Python ${{ matrix.python-version }} for ES ${{ matrix.elasticsearch-version }}
     strategy:


### PR DESCRIPTION
This PR updates the version of the release GitHub action to use `ubuntu-latest` instead of `ubuntu-18.04` wich is deprecated.

More info: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/