### PR TITLE
[release] Check dependencies in PyPI instead of sleep

### DIFF
--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -46,7 +46,6 @@ jobs:
       module_repository: 'chaoss/grimoirelab-toolkit'
       module_directory: 'src/grimoirelab-toolkit'
       dependencies: ''
-      check_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -63,7 +62,6 @@ jobs:
       module_repository: 'chaoss/grimoirelab-kidash'
       module_directory: 'src/grimoirelab-kidash'
       dependencies: ''
-      check_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -81,7 +79,6 @@ jobs:
       module_repository: 'chaoss/grimoirelab-sortinghat'
       module_directory: 'src/grimoirelab-sortinghat'
       dependencies: '${{ needs.grimoirelab-toolkit.outputs.package_version }}'
-      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -99,7 +96,6 @@ jobs:
       module_repository: 'chaoss/grimoirelab-cereslib'
       module_directory: 'src/grimoirelab-cereslib'
       dependencies: '${{ needs.grimoirelab-toolkit.outputs.package_version }}'
-      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -116,7 +112,6 @@ jobs:
       module_repository: 'chaoss/grimoirelab-sigils'
       module_directory: 'src/grimoirelab-sigils'
       dependencies: ''
-      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -134,7 +129,6 @@ jobs:
       module_repository: 'chaoss/grimoirelab-perceval'
       module_directory: 'src/grimoirelab-perceval'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }}"
-      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -154,7 +148,6 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-mozilla'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -174,7 +167,6 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-opnfv'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -194,7 +186,6 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-puppet'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -214,7 +205,6 @@ jobs:
       module_directory: 'src/grimoirelab-perceval-weblate'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -234,7 +224,6 @@ jobs:
       module_directory: 'src/grimoirelab-graal'
       dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
       ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-      check_dependencies: true
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -268,7 +257,6 @@ jobs:
       ${{ needs.grimoirelab-perceval-weblate.outputs.package_version }} \
       ${{ needs.grimoirelab-graal.outputs.package_version }} \
       ${{ needs.grimoirelab-sortinghat.outputs.package_version }}"
-      check_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -308,7 +296,6 @@ jobs:
       ${{ needs.grimoirelab-perceval-weblate.outputs.package_version }} \
       ${{ needs.grimoirelab-graal.outputs.package_version }} \
       ${{ needs.grimoirelab-cereslib.outputs.package_version }}"
-      check_dependencies: false
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 

--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -31,11 +31,6 @@ on:
         description: 'Package dependencies and their version'
         type: string
         required: true
-      check_dependencies:
-        description: 'Check dependencies are available. If false and has dependencies, wait 180 seconds'
-        type: boolean
-        default: true
-        required: false
     secrets:
       access_token:
         description: 'Token for updating repositories'
@@ -103,7 +98,6 @@ jobs:
 
       - id: check-dependencies
         name: Check is package dependencies are ready
-        if: inputs.check_dependencies == true
         run: |
           dependencies="${{ inputs.dependencies }}"
           if [ ! -z "$dependencies" ]
@@ -125,12 +119,6 @@ jobs:
             exit 1
           fi
         working-directory: ${{ inputs.module_directory }}
-
-      - id: wait-pypi
-        name: Wait for dependencies to be ready in PyPI
-        if: (inputs.check_dependencies == false) && (inputs.dependencies != '')
-        run: |
-          sleep 180
 
       - id: update-dependencies
         name: Update package dependencies


### PR DESCRIPTION
This PR standardizes the way the packages wait for dependencies ready in PyPI. Previously, certain packages required a sleep delay because the Poetry command was slow. That issue was addressed, and now it checks the dependencies more efficiently.