### PR TITLE
[release] Poetry add no longer updates the dependencies

### DIFF
--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -463,6 +463,7 @@ jobs:
               "${{ needs.grimoirelab-graal.outputs.package_version }}" \
               "${{ needs.grimoirelab-elk.outputs.package_version }}" \
               "${{ needs.grimoirelab-sirmordred.outputs.package_version }}"
+          poetry update --lock
 
           cat << EOF > requirements.txt
           grimoirelab==${{ steps.semverup.outputs.version }}


### PR DESCRIPTION
This PR includes a `poetry update` after adding the new versions of the packages to update all the dependencies in the release workflow.