### PR TITLE
[actions] Pin GrimoireLab depnendencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           artifact-name: grimoirelab-dist
           artifact-path: dist
+          pin-dependencies: yes
 
   tests:
     needs: [build]


### PR DESCRIPTION
This PR includes a new input to the `build` action of the release to pin the dependencies of the GrimoireLab package.