### PR TITLE
[gha] Update cosign-installer action to v.3.1.2

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,7 +58,7 @@ jobs:
     environment: docker-release
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@7cc35d7fdbe70d4278a0c96779081e6fac665f88 # v2.8.0
+        uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
       - name: Docker metadata
         id: meta


### PR DESCRIPTION
This commit updates the action to install cosign in the docker release workflow.