### PR TITLE
Update governance rules for GrimoireLab project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,218 +1,88 @@
 # Contributing to GrimoireLab
 
-These are some general guidelines and information related to how we contribute to GrimoireLab.
+There are multiple ways to contribute to GrimoireLab. You can help other
+users solve their issues running the platform, report issues you might have
+found using in our software, propose new ideas, improve documentation,
+and even write code to add new features or fix existing bugs.
 
-GrimoireLab is a part of the [Software Technical Committee](https://wiki.linuxfoundation.org/chaoss/software) of the [CHAOSS Collaborative Project](http://chaoss.community).
+The following is information and general guidelines for collaborating with us.
 
-## Communication means
+## Before You Contribute
 
-GrimoireLab  use the following communication channels:
+Before opening a new discussion, bug, issue, etc, please check if similar one
+has already been reported. This helps us avoid duplication of effort and keeps
+our discussions and issues focused.
 
-* Mailing list
-* Slack
-* Issues / pull requests
+Also, please check our [Code of Conduct](https://github.com/chaoss/.github/blob/main/CODE_OF_CONDUCT.md).
+GrimoireLab is part of the [CHAOSS Collaborative Project](http://chaoss.community)
+and any participation in their projects is subject to their Code of Conduct.
 
-Each of them is intended for an specific purpose. Please understand
-that you may be redirected to some other mean if the communication you
-intend to have is considered to fit better elsewhere.
+## How Can I Contribute?
 
-### Mailing list
+### Reporting Bugs
 
-List:
-[grimoirelab-discussions@lists.linuxfoundation.org](https://lists.linuxfoundation.org/mailman/listinfo/grimoirelab-discussions)
+If you find an error while running the platform, we would appreciate you
+opening an issue to report it.
 
-We use the list for:
+As GrimoireLab is built by several components across some GitHub repositories,
+You may not know exactly where to open the issue. Unless you know
+exactly on which component the bug is, open the issue on the main repository.
+Maintainers will move the issue if they see the issue is related to another
+repository.
 
-* Discussions related to the management of the project, including the
-relationship with the CHAOS Software Technical Committee.
-* General announcements, including information about releases.
-* General discussions about the future of the project, relationship
-with other projects, new features or refactorings that really don't fit
-in other communication means.
-* Questions and community support that really don't fit in other
-communication means.
+### Suggesting Enhancements
+
+If you have ideas for improvements or new features, feel free to open a new
+discussion or issue to share them. We appreciate well-documented
+enhancement suggestions. You can also have at look to our [ROADMAP](./ROADMAP.md)
+to check if your proposal is aligned with the current direction of the
+platform.
+
+### Writing Code
+
+All contributions to current repositories in GrimoireLab will be received as
+pull requests in the corresponding repository. GitHub has a
+[complete guide](https://docs.github.com/es/pull-requests) on
+collaborating via pull requests but, in short, you will do the following:
+
+1. Fork the repository.
+1. Create a new branch for your feature or bug fix.
+1. Make your changes and test them thoroughly.
+1. Create a pull request (PR) with a clear title and description.
+1. Ensure your PR follows our coding standards.
+
+If you're interested in contributing with code, please also have a look
+at the specifics in our [CONTRIBUTING WITH CODE](./CONTRIBUTING_WITH_CODE.md)
+document.
+
+## How Can I Communicate with the GrimoireLab Community?
+
+In GrimoireLab we use the communication channels listed below, each one of them
+intended for a specific purpose.
+
+### GitHub Discussions
+
+We use [this site](https://github.com/chaoss/grimoirelab/discussions) for:
+
+- General announcements, such as information about releases.
+- Questions and community support.
+- General discussions about the future of the project, relationship
+  with other projects, new features or changes that don't fit
+  in other communication channels.
+- Discussions related to the management of the project, including the
+  relationship with the **CHAOSS Software Technical Committee**.
+
+### GitHub Issues / Pull Requests
+
+Most of the technical work is discussed here, including upgrades and
+proposals for upgrades, bug fixing and feature requests.
 
 ### Slack
 
-Channel: [`#grimoirelab`](https://chaoss-workspace.slack.com/archives/C022NPTPC8Z) 
-at [CHAOSS Slack](https://join.slack.com/t/chaoss-workspace/shared_invite/zt-r65szij9-QajX59hkZUct82b0uACA6g)
+You can fin us on [`#grimoirelab`](https://chaoss-workspace.slack.com/archives/C022NPTPC8Z)
+channel at [CHAOSS Slack](https://join.slack.com/t/chaoss-workspace/shared_invite/zt-r65szij9-QajX59hkZUct82b0uACA6g).
 
 We use the channel for pinging people, sharing updates, quick and informal
-discussions, questions and answers, etc. Please, don't consider that
-developers in the channel will be always available, or always willing
-to answer questions and comments. However, anyone interested in the
-project is welcome to join the channel and hang around.
-
-### Pull request / issues
-
-Repositories: [GrimoireLab repositories in GitHub](http://github.com/chaoss/grimoirelab), which are all in the [CHAOSS organization](http://github.com/chaoss).
-
-Most of the work is discussed here, including upgrades and
-proposals for upgrades, bug fixing and feature requests. For any of
-these, open an issue in the corresponding repository. If in doubt, ask in
-the IRC channel, or try in any one: if needed you will be redirected to
-the right repository. If you are proposing code change, open a pull request.
-
-## DCO and Sign-Off for contributions
-
-The [CHAOSS Charter](https://github.com/chaoss/governance/blob/master/project-charter.md) requires that contributions
-are accompanied by a [Developer Certificate of Origin](http://developercertificate.org) sign-off.
-For ensuring it, a bot checks all incoming commits.
-
-For users of the git command line interface, a sign-off is accomplished with the `-s` as part of the commit command: 
-
-```
-git commit -s -m 'This is a commit message'
-```
-
-For users of the GitHub interface (using the "edit" button on any file, and producing a commit from it),
-a sign-off is accomplished by writing
-
-```
-Signed-off-by: Your Name <YourName@example.org>
-```
-
-in a single line, into the commit comment field. This can be automated by using a browser plugin like
-[DCO GitHub UI](https://github.com/scottrigby/dco-gh-ui).
-
-## Committers
-
-Committers have the permision to merge code in GrimoireLab. Committers
-can be for all GrimoireLab, or for specific repositories.
-
-New committers will be proposed by committers, and accepted (granted
-committer rights) by an action vote among committers (see below).
-Developers can apporach committers to ask to be proposed as comitter.
-Main rule for acceptance of new committers will be their merits on the
-project, including past contributions and expertise.
-
-Committers may resign if they are no longer involved enough in the
-project. Committers can also propose the removal of other committer
-rights, in case they are no longer involved in the project. For being
-removed, after the proposal there will be an action voting among
-committers, except for the one being proposed to be removed.
-
-The current list of committers is (GitHub handles):
-
-* General: @sduenas, @acs, @dicortazar, @sanacl, @jgbarah, @jsmanrique, @valcos
-* Manuscripts: @alpgarcia
-* Sigils: @alpgarcia
-
-## Voting on action items (action votes)
-
-Action items will be decided by public votes in the mailing list for
-the project. Anyone in the mailing list can vote, to express their
-opinion, but the result of the vote will have into account only the
-votes by general committers.
-
-Votes will be casted as (details taken in part from the Apache
-project):
-
--  +1: Yes, agree, or the action should be performed.
--    0 : Abstain, no opinion, or I am happy to let the other group members
-decide this issue.
-- -1: No, I veto this action. All vetos must include an explanation of
-why the veto is appropriate. A veto with no explanation is void.
-
-A period of four days, since the moment the action item is proposed,
-will be valid for casting votes. Any comitter can propose an action
-vote, which will be effective if at least two other committers agree
-during a period of two days. The voting period will start when the
-proposer sends a message stating that, after the second agreement is
-received.
-
-Action votes will be mandatory for:
-
-* Accepting a new committer.
-* Proposal for removal of committer rights.
-* Accepting a new repository in the project.
-* Removing a repository from the project.
-* Deciding that some certain code in some repository needs to be moved
-to some other repository.
-
-In all the cases, the action vote will pass with at least 3 positive
-votes and no vetos.
-
-## Accepting contributions
-
-Except for a few exceptions, all contributions to current repositories
-in GrimoireLab will be received as pull requests in the corresponding
-repository. They will be reviewed by at least one committer before
-being accepted. Anyone is welcome to comment on pull requests.
-
-Except in very special circumstances, that should be defined,
-contributions will be accepted under the GPLv3 (GNU Public License
-version 3).
-
-The list of current repositories is the list of projects in the
-GrimoireLab organization in GitHub.
-
-#### Guidelines to follow to write good commit messages
-Writing a well-crafted Git commit message is the best way to
-communicate context about a change to fellow developers.
-
- Seven rules of a great Git commit message are mentioned in 
- [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/):
-
-1. Separate subject from body with a blank line
-1. Limit the subject line to 50 characters
-1. Capitalize the subject line and (optionally) 
-start the subject with a tag
-1. Do not end the subject line with a period
-1. Use the imperative mood in the subject line
-1. Wrap the body at 72 characters
-1. Use the body to explain what and why vs. how
-
-The below git commit message is a good example which follows
-the above rules.
-
-```
-Summarize changes in around 50 characters or less
-
-More detailed explanatory text, if necessary. Wrap it to about 72
-characters or so. In some contexts, the first line is treated as the
-subject of the commit and the rest of the text as the body. The
-blank line separating the summary from the body is critical (unless
-you omit the body entirely); various tools like `log`, `shortlog`
-and `rebase` can get confused if you run the two together.
-
-Explain the problem that this commit is solving. Focus on why you
-are making this change as opposed to how (the code explains that).
-Are there side effects or other unintuitive consequences of this
-change? Here's the place to explain them.
-
-Further paragraphs come after blank lines.
-
- - Bullet points are okay, too
-
- - Typically a hyphen or asterisk is used for the bullet, preceded
-   by a single space, with blank lines in between, but conventions
-   vary here
-
-If you use an issue tracker, put references to them at the bottom,
-like this:
-
-Resolves: #123
-See also: #456, #789
-```
-
-## Incubating repositories
-
-In some cases, activity related to GrimoireLab may start in
-repositories outside the GrimoireLab project. In that case, if the
-developers collaborating in those repositories want, they can inform
-GrimoireLab of their progress, and propose coordianted actions (such as
-definition of APIs). However, they will be considered external projects
-until the moment they are accepted as repositories in GrimoireLab, via
-an action vote.
-
-## Merging contributions
-
-TBD
-
-## Releases
-
-GrimoireLab will deliver frequent coordinated releases of several of
-the code in its repositories. Those releases should have passed some
-testing procedures known to the project. Releases will be announced in
-the mailing list.
+discussions, questions and answers, etc. Please, remember that developers
+in the channel won't always be available. However, anyone interested in the
+project is welcome to join the channel and start a discussion.

--- a/CONTRIBUTING_WITH_CODE.md
+++ b/CONTRIBUTING_WITH_CODE.md
@@ -1,0 +1,206 @@
+# Contributing with Code
+
+Before submitting your code, please make sure that:
+
+- Your code follows the coding standards.
+- You've added relevant tests and documentation.
+- All tests pass successfully.
+- Your commits are [rebased](https://docs.github.com/en/get-started/using-git/about-git-rebase).
+- Your commits are well-documented ([see below](#how-to-write-good-commit-messages)).
+- The commits are signed with a Developer Certificate Origin
+  ([see below](#developer-certificate-origin)).
+- You include a changelog entry ([see below](#changelog-entries)).
+
+Your contribution will be reviewed by at least one maintainer before
+being accepted. Anyone is welcome to comment on pull requests.
+
+## How to Write Good Commit Messages
+
+Writing a well-crafted Git commit message is the best way to communicate
+context about a change.
+
+The following are some tips to help you writing a great commit message:
+
+1. Separate the subject from the body with a blank line.
+1. Limit the subject line to 50 characters.
+1. Capitalize the subject line and (optionally) start the subject with a tag.
+1. Do not end the subject line with a period.
+1. Use the imperative mood in the subject line.
+1. Wrap the body at 72 characters.
+1. Use the body to explain what and why rather than how.
+
+The following is a good example of an effective commit message.
+
+```text
+Summarize changes in around 50 characters or less
+
+More detailed explanatory text, if necessary. Keep it to about 72
+characters. In some contexts, the first line is treated as the
+subject of the commit and the rest of the text as the body. The
+blank line separating the summary from the body is critical (unless
+you omit the body entirely); various tools like `log`, `shortlog`
+and `rebase` can get confused if you run the two together.
+
+Explain the problem that this commit is solving. Focus on why you
+are making this change as opposed to how (the code explains that).
+Are there side effects or other unintuitive consequences of this
+change? Here's the place to explain them.
+
+Further paragraphs come after blank lines.
+
+ - Bullet points are okay, too
+
+ - Typically a hyphen or asterisk is used for the bullet, preceded
+   by a single space, with blank lines in between, but conventions
+   vary here
+
+If you use an issue tracker, put references to them at the bottom,
+like this:
+
+Resolves: #123
+See also: #456, #789
+```
+
+You can find the full description of these rules with examples on the post
+[How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/)
+by Chris Beams (kudos to Chris!)
+
+## Developer Certificate Origin
+
+GrimoireLab is a free, libre, and open source software released under the
+GNU Public License version 3 (GPL3). The purpose of the
+[Developer Certificate of Origin (DCO)](http://developercertificate.org) is
+to confirm that you have the legal right to contribute your work and you are
+willing to have it included in the project under the terms of the GPL3.
+
+The [CHAOSS Charter](https://github.com/chaoss/governance/blob/master/project-charter.md)
+requires that contributions are accompanied by a [DCO](http://developercertificate.org)
+sign-off.
+
+By signing your commits, you acknowledge that you have read and agree to the DCO.
+
+You must sign your commits by adding a line like this to your commit message:
+
+```text
+Signed-off-by: Your Name <YourName@example.org>
+```
+
+This can be automatically added to your commits using the `-s` or `--signoff`
+option with `git commit`.
+
+## Changelog Entries
+
+Some of your contributions will require a changelog entry which explains the
+motivation for the change. These entries are included in the **Release Notes**
+to explain to users and developers the new features or bugs fixed in the
+software. This is an example of changelog entry:
+
+```yaml
+title: 'Fix bug casting spells on magicians'
+category: fixed
+author: John Smith <jsmith@example.com>
+issue: 666
+notes: >
+    The bug was making it impossible to cast a spell on
+    a magician.
+```
+
+Changelog entries will be written to explain *what* was changed and *why*,
+not *how*. Take into account that not everyone is a developer and the entries
+are meant to reach a wider audience.
+
+The Python package [release-tools](https://github.com/Bitergia/release-tools/)
+will help you in this process. Just install the package and run the command
+`changelog` on the repository where you made the change.
+
+```terminal
+pip install release-tools
+changelog
+```
+
+### What Warrants a Changelog Entry
+
+Changelog entries are **required** for:
+
+- Code changes that directly affects the GrimoireLab users.
+- Bug fixes.
+- New updates.
+- Performance improvements.
+
+Changelog entries are **not required** for
+
+- Docs-only (e.g., README.md) changes.
+- Developer-facing change (e.g., test suite changes).
+- Code refactoring.
+
+### Writing Changelog Entries
+
+These changelog entries should be written to the `releases/unreleased/`
+directory. The file is expected to be a [YAML](https://yaml.org/) file
+in the following format:
+
+```yaml
+title: 'Fix bug casting spells on magicians'
+category: fixed
+author: John Smith <jsmith@example.com>
+issue: 666
+notes: >
+    The bug was making impossible to cast a spell on
+    a magician.
+```
+
+The `title` field has the name of the change. This is a mandatory field.
+
+The `category` field maps the category of the change. Valid options are:
+`added`, `fixed`, `changed`, `deprecated`, `removed`, `security`,
+`performance`, `dependency`, and `other`. This field is mandatory.
+
+The `author` key (format: `Your Name <YourName@example.org>`) is used to
+give credit to community contributors. This is an optional field but
+the community contributors are encouraged to add their names.
+
+The `issue` value is a reference to the issue, if any, that is targeted
+with this change. This is an optional field.
+
+The `notes` field should have a description explaining the changes in the
+code. Remember you can write blocks of text using the `>` character at the
+beginning of each block. See the above example.
+
+Contributors can use the interactive [changelog](https://github.com/Bitergia/release-tools#changelog)
+tool, which generates the changelog entry file automatically.
+
+### Tips for Writing Effective Changelog Entries
+
+An effective changelog entry should be descriptive and concise. It should explain
+the change to a reader who has *zero context* about the change. If you have
+trouble making it both concise and descriptive, err on the side of descriptive.
+
+Use your best judgment and try to put yourself in the mindset of someone
+reading the compiled changelog. Does this entry add value? Does it offer
+context about *what* was changed and *why*?
+
+### Examples
+
+- **Bad:** Go to a project order.
+- **Good:** Show a user’s starred projects at the top of the “Go to project” dropdown.
+
+The first example provides no context of where or why the change was made, or
+how it benefits the user.
+
+- **Bad:** Copy (some text) to clipboard.
+- **Good:** Update the “Copy to clipboard” tooltip to indicate what’s being copied.
+
+Again, the first example is too vague and provides no context.
+
+- **Bad:** Fixes and Improves CSS and HTML problems in mini pipeline graph and builds dropdown.
+- **Good:** Fix tooltips and hover states in mini pipeline graph and builds dropdown.
+
+The first example is too focused on implementation details. The user doesn’t care
+that we changed CSS and HTML, they care about the result of those changes.
+
+- **Bad:** Strip out `nil`s in the Array of Commit objects returned from `find_commits_by_message_with_elastic`
+- **Good:** Fix 500 errors caused by Elasticsearch results referencing garbage-collected commits
+
+The first example focuses on *how* we fixed something, not on *what* it fixes.
+The rewritten version clearly describes the *end benefit* to the user
+(fewer 500 errors), and *when* (searching commits with Elasticsearch).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,106 @@
+# Governance in GrimoireLab
+
+The following norms describe how GrimoireLab is managed.
+
+GrimoireLab is part of the [CHAOSS Collaborative Project](http://chaoss.community)
+and any participation in their projects is subject to their norms.
+
+## Code of Conduct
+
+We follow the [Code of Conduct](https://github.com/chaoss/.github/blob/main/CODE_OF_CONDUCT.md)
+defined by **CHAOSS**.
+
+## License
+
+GrimoireLab code is distributed under the GNU Public License v.3.
+Contributions will be accepted under this license, except in very special
+circumstances that should be defined.
+
+## Roadmap
+
+We use a roadmap to outline the direction of GrimoireLab. In the
+[ROADMAP](./ROADMAP.md) document, we describe the vision and goals of
+the project and what actions we'll take to achieve them.
+
+Our actions are grouped by **themes**, which define the needs and problems
+to solve for at the present time. Everything we develop for GrimoireLab
+must be related to a theme. These themes will help us to determine what's
+relevant for the project and what's not. It will help us say *yes* or *no*
+when new features are requested or when discussions take place.
+
+It's also important to note that the roadmap is not something written in
+stone. It can change and evolve according to the needs of our community.
+We'll run open discussions where we can evaluate the current status of the
+project and update the roadmap.
+
+We'll manage the roadmap and track all the activity using GitHub project
+boards, issues, and pull requests.
+
+Finally, take into account that all the information we provide in the roadmap
+**IS FOR INFORMATIONAL PURPOSES ONLY** and **IS SUBJECT TO CHANGE WITHOUT NOTICE**.
+
+## Maintainers
+
+The maintainers of the project have permission to merge code in GrimoireLab.
+
+New maintainers will be proposed by maintainers and accepted (granted
+committer and maintainer rights) by an action vote among other maintainers
+([see below](#voting-on-action-items)).
+
+Developers can approach maintainers to ask to be proposed as a maintainer.
+The main rule for acceptance of new maintainers will be their merits on the
+project, including past contributions and expertise.
+
+Maintainers may resign if they are no longer involved enough on the project.
+They can also propose the removal of other maintainer's rights if they are
+no longer involved on the project. After the proposal to remove someone,
+there will be an action vote by maintainers, except for the one proposed
+for removal.
+
+The list of current maintainers will be updated in the [MAINTAINERS file](./MAINTAINERS.md).
+
+## Voting on Action Items
+
+Action items will be decided by public votes in GitHub Discussions. Anyone
+can vote, to express their opinion, but the result of the vote will take into
+account only the votes by general maintainers.
+
+Votes will be cast in the following ways (details taken in part from the
+Apache project):
+
+- `+1`: Yes, agree, or the action should be performed.
+- `0` : Abstain, no opinion, or I am happy to let the other group members
+  decide this issue.
+- `-1`: No, I veto this action. All vetoes must include an explanation of
+  why the veto is appropriate. A veto with no explanation is void.
+
+Any maintainer can propose an action vote, and it will become effective if at
+least 2 other maintainers agree during a period of two days. Then maintainers
+will have 4 days to cast their votes on the proposal.
+
+Action votes will be mandatory for:
+
+- Accepting a new maintainer.
+- Proposal for removal of maintainer rights.
+- Accepting a new repository in the project.
+- Removing a repository from the project.
+- Deciding that some certain code in some repository needs to be moved to
+  some other repository.
+
+In all the cases, the action vote will pass with at least 3 positive votes and
+no vetoes.
+
+## Contributions
+
+The general norms for contributions are described in the
+[CONTRIBUTING](./CONTRIBUTING.md) and [CONTRIBUTING WITH CODE](./CONTRIBUTING_WITH_CODE.md)
+documents.
+
+## Incubating repositories
+
+Sometimes, activity related to GrimoireLab may start in repositories
+outside the GrimoireLab project. In those cases, if the developers collaborating
+on those repositories want, they can inform GrimoireLab of their progress, and
+propose coordinated actions (such as definition of APIs). However, they will be
+considered external projects until the moment they are accepted as repositories
+in GrimoireLab, via an action vote.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # GrimoireLab Maintainers
 
-- Santiago Dueñas (@sduenasd) - Tech Lead & Developer
+- Santiago Dueñas (@sduenas) - Tech Lead & Developer
 - Quan Zhou (@zhquan) - Developer
 - Eva Millán (@evamillan) - Developer
 - Jose Javier Merchante (@jjmerchante) - Developer

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,6 @@
+# GrimoireLab Maintainers
+
+- Santiago Dueñas (@sduenasd) - Tech Lead & Developer
+- Quan Zhou (@zhquan) - Developer
+- Eva Millán (@evamillan) - Developer
+- Jose Javier Merchante (@jjmerchante) - Developer


### PR DESCRIPTION
Governance rules have been updated to make them more clear and to align the project with CHAOSS. This commit also improves the rules and recommendations for contributing to the project.