### PR TITLE
Create log volume matching ${DEPLOY_USER_DIR}

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
 RUN echo "${DEPLOY_USER} ALL=NOPASSWD: ALL" >> /etc/sudoers
 
 RUN mkdir -p ${DEPLOY_USER_DIR}/logs ; chown -R ${DEPLOY_USER}:${DEPLOY_USER} ${DEPLOY_USER_DIR}/logs
-VOLUME ["/home/bitergia/logs"]
+VOLUME ["${DEPLOY_USER_DIR}/logs"]
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \


### PR DESCRIPTION
The grimoirelab container uses `${DEPLOY_USER_DIR}` as working directory, but created a volume under `/home/bitergia/logs`. This commit fixes the path of the log volume, which makes it possible to start grimoirelab container with a read-only root filesystem.

![image](https://github.com/chaoss/grimoirelab/assets/29982899/2f4dbdff-c196-43ea-a096-4fd54689df6b)
