### PR TITLE
Add adopters file

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -9,8 +9,8 @@ The list of organizations that have publicly shared the usage of GrimoireLab:
 
 | Organization                      | Success Story                                                                                                                                  |
 |:----------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
-| [Bitergia](https://bitergia.com/) | We provide a ready-to-use platform - built on top of GrimoireLab - to empower managers to reach their business goals with Open Source metrics. |
-<!-- append the line below to the table
+| [Bitergia](https://bitergia.com/) | We offer a commercial ready-to-use platform, built with GrimoireLab, that gives managers software development analytics for the projects they care about. |
+<!-- to append the table: insert a line above, using the format below
 | [name](URL) | brief description of how you are using GrimoireLab |
 -->
 

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,18 @@
+# GrimoireLab Adopters
+
+This is the list of organizations and users that have publicly shared how
+they are using GrimoireLab.
+
+💡 **Add your organization by creating a PR**
+
+The list of organizations that have publicly shared the usage of GrimoireLab:
+
+| Organization                      | Success Story                                                                                                                                  |
+|:----------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
+| [Bitergia](https://bitergia.com/) | We provide a ready-to-use platform - built on top of GrimoireLab - to empower managers to reach their business goals with Open Source metrics. |
+<!-- append the line below to the table
+| [name](URL) | brief description of how you are using GrimoireLab |
+-->
+
+**Note**: we took the idea and format of this file from the
+[Kyverno project](https://github.com/kyverno/kyverno/). Kudos to them!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,3 +86,8 @@ We use the channel for pinging people, sharing updates, quick and informal
 discussions, questions and answers, etc. Please, remember that developers
 in the channel won't always be available. However, anyone interested in the
 project is welcome to join the channel and start a discussion.
+
+### Adopters List
+
+You can publicly share how you or your organization are using GrimoireLab
+by adding an entry to the [ADOPTERS](./ADOPTERS.md) file.


### PR DESCRIPTION
The purpose of this file is to show how organizations and users are using GrimoireLab. We took this idea from the Kyverno project.