### PR TITLE
Update documentation with a link to OpenSearch panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ foo@bar:~/grimoirelab/docker-compose$ docker-compose up -d
 
 Your dashboard will be ready after a while at `http://localhost:8000`. The waiting time depends on the amount of data to fetch from a repo, for small repositories you can expect your data to be visible in the dashboard after 10-15 minutes.
 
-More details in the [docker-compose folder](./docker-compose/README.md).
+More details or troubleshooting in the [docker-compose folder](./docker-compose/README.md).
 
 ## Using `docker run`
 

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -121,6 +121,10 @@ asked to log in:
 * User: `admin`
 * Password: `admin`
 
+This version doesn't come with visualizations. You need to manually import the dashboards
+from [Sigils repository](https://github.com/chaoss/grimoirelab-sigils/tree/master/panels/json/opensearch_dashboards)
+or create your own.
+
 For more information related with OpenSearch: https://opensearch.org/docs/latest/
 
 
@@ -135,7 +139,14 @@ For more information related with OpenSearch: https://opensearch.org/docs/latest
 
 ## Common questions
 
-**How to stop and restart deployed software infrastructure?**
+### ElasticSearch container won't start up on Mac
+
+Running the default `docker-compose.yml` in Mac caused issues with the provided
+versions of Elasticsearch and Kibana. To resolve these problems, please use
+the [OpenSearch version](#opensearch).
+
+
+### How to stop and restart deployed software infrastructure?
 
 There might be 2 potential scenarios:
 


### PR DESCRIPTION
This PR updates the README to include a link to the available visualizations for OpenSearch in the Sigils repository. Additionally, it adds a common question related to Mac users.