### PR TITLE
Fix missing release notes in NEWS file

### DIFF
--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -585,7 +585,7 @@ jobs:
           cat $release_file
 
       - name: Generate NEWS from packages
-        if: inputs.release_candidate == 'false' && steps.custom_notes.outputs.custom_notes == 'false'
+        if: inputs.release_candidate == false && steps.custom_notes.outputs.custom_notes == 'false'
         env:
           notes_grimoirelab_toolkit: "${{ needs.grimoirelab-toolkit.outputs.notes}}"
           notes_kidash: "${{ needs.grimoirelab-kidash.outputs.notes}}"


### PR DESCRIPTION
This PR fixes a bug in the workflow that prevented the NEWS file from being updated. The issue occurred because a boolean input in the `if` condition must be compared with a boolean value. Additionally, the boolean input in the run section must be compared as a string.