### PR TITLE
Remove python3 installation from Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,11 +20,6 @@ RUN apt-get update && \
         bash locales \
         gcc \
         git git-core \
-        python3 \
-        python3-pip \
-        python3-venv \
-        python3-dev \
-        python3-gdbm \
         mariadb-client \
         libmariadbclient-dev-compat \
         unzip curl wget sudo ssh \


### PR DESCRIPTION
This PR removes the installation of Python 3 and associated packages from the Dockerfile. These packages were introducing a vulnerability related to `python-wheel`. This change eliminates the risk by removing the unnecessary packages because Python has already been installed.