### PR TITLE
Fix SortingHat static files path

### DIFF
--- a/docker-compose/docker-compose-opensearch.yml
+++ b/docker-compose/docker-compose-opensearch.yml
@@ -83,7 +83,7 @@ services:
       expose:
         - "9314"
       volumes:
-        - sortinghat-static:/opt/venv/lib/python3.9/site-packages/sortinghat/static/
+        - sortinghat-static:/opt/venv/lib/python3.8/site-packages/sortinghat/static/
       depends_on:
         mariadb:
           condition: service_healthy

--- a/docker-compose/docker-compose-secured.yml
+++ b/docker-compose/docker-compose-secured.yml
@@ -74,7 +74,7 @@ services:
       expose:
         - "9314"
       volumes:
-        - sortinghat-static:/opt/venv/lib/python3.9/site-packages/sortinghat/static/
+        - sortinghat-static:/opt/venv/lib/python3.8/site-packages/sortinghat/static/
       depends_on:
         mariadb:
           condition: service_healthy

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       expose:
         - "9314"
       volumes:
-        - sortinghat-static:/opt/venv/lib/python3.9/site-packages/sortinghat/static/
+        - sortinghat-static:/opt/venv/lib/python3.8/site-packages/sortinghat/static/
       depends_on:
         mariadb:
           condition: service_healthy


### PR DESCRIPTION
This PR updates the path for the SortingHat static files served by NGINX due to the switch to a different Python version.