### PR TITLE
Add Security Policy document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,11 @@ If you're interested in contributing with code, please also have a look
 at the specifics in our [CONTRIBUTING WITH CODE](./CONTRIBUTING_WITH_CODE.md)
 document.
 
+## Notifying about vulnerabilities
+
+If you discover a vulnerability, please follow the instructions described
+in the [Security Policy](./SECURITY.md) document to report your findings.
+
 ## How Can I Communicate with the GrimoireLab Community?
 
 In GrimoireLab we use the communication channels listed below, each one of them

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,6 +16,12 @@ GrimoireLab code is distributed under the GNU Public License v.3.
 Contributions will be accepted under this license, except in very special
 circumstances that should be defined.
 
+## Security
+
+The GrimoireLab maintainers take all security issues in the project seriously.
+You can find all our security policies in the [Security Policy](./SECURITY.md)
+document.
+
 ## Roadmap
 
 We use a roadmap to outline the direction of GrimoireLab. In the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# GrimoireLab Security Policy
+
+This document describes the security procedures and general policies for the
+GrimoireLab project.
+
+## Reporting a Vulnerability
+
+The GrimoireLab maintainers take all security issues in the project seriously.
+Thank you for improving the security of our project. We appreciate your
+efforts to responsible disclose your findings, and will make every effort to
+acknowledge your contributions.
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, use the GitHub Security Advisory
+[Report a Vulnerability](https://github.com/chaoss/grimoirelab/security/advisories/new)
+tab.
+
+Here are some helpful details to include in your report:
+
+- A detailed description of the vulnerability.
+- The steps required to reproduce the vulnerability.
+- Any suggested fixes or mitigations.
+
+To learn more about how to submit a vulnerability report, please check
+the [GitHub's documentation on private reporting](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+
+The GrimoireLab team will respond to your report indicating the next steps. We
+will keep you informed of the progress addressing the vulnerability, and may
+ask for additional information or guidance.


### PR DESCRIPTION
This document describes the GrimoireLab security policies, including how to report vulnerabilities.