### PR TITLE
Migrate files for branch rename from master to main

### DIFF
--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -705,9 +705,9 @@ jobs:
         run: |
           if [ ${{ inputs.release_candidate }} == 'true' ]
           then
-            publish ${{ steps.semverup.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --no-cleanup
+            publish ${{ steps.semverup.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --remote-branch main --no-cleanup
           else
-            publish ${{ steps.semverup.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin
+            publish ${{ steps.semverup.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --remote-branch main
           fi
 
       - id: wait-for-release
@@ -747,7 +747,7 @@ jobs:
         if: steps.wait-for-release.outcome == 'failure'
         run: |
           git reset --hard HEAD~1
-          git push -f origin master
+          git push -f origin main
           git tag -d ${{ steps.semverup.outputs.version }}
           git push --delete origin ${{ steps.semverup.outputs.version }}
 

--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           git submodule update --init --remote ${{ inputs.module_directory }}
           cd ${{ inputs.module_directory }}
-          git checkout master
+          git checkout main
 
       - name: Install poetry
         run: |
@@ -243,9 +243,9 @@ jobs:
         run: |
           if [ ${{ inputs.release_candidate }} == 'true' ]
           then
-            publish ${{ steps.version.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --no-cleanup
+            publish ${{ steps.version.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --remote-branch main --no-cleanup
           else
-            publish ${{ steps.version.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin
+            publish ${{ steps.version.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --remote-branch main 
           fi
         working-directory: ${{ inputs.module_directory }}
 
@@ -323,7 +323,7 @@ jobs:
           else
             git reset --hard HEAD~1
           fi
-          git push -f origin master
+          git push -f origin main
           git tag -d ${{ steps.version.outputs.version }}
           git push --delete origin ${{ steps.version.outputs.version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build package using Poetry and store result
-        uses: chaoss/grimoirelab-github-actions/build@master
+        uses: chaoss/grimoirelab-github-actions/build@main
         with:
           artifact-name: grimoirelab-dist
           artifact-path: dist
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create a new release on the repository
-        uses: chaoss/grimoirelab-github-actions/release@master
+        uses: chaoss/grimoirelab-github-actions/release@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish the package on PyPI
-        uses: chaoss/grimoirelab-github-actions/publish@master
+        uses: chaoss/grimoirelab-github-actions/publish@main
         with:
           artifact-name: grimoirelab-dist
           artifact-path: dist

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -19,6 +19,7 @@ The list of organizations that have publicly shared the usage of GrimoireLab:
 | [Google](https://www.google.com/) | Various open source project teams within Google have explored GrimoireLab to monitor community health and collect operational feedback. |
 | [FreeBSD](https://grimoire.freebsd.org/) | Dashboards customized by Bitergia for bug characterization to help with understanding and managing the backlog.|
 | [Thunderbird](https://www.thunderbird.net/) | The [Thunderbird dashboard](https://thunderbird.biterg.io/) is hosted by Bitergia and helps [visualize the Thunderbird community](https://blog.thunderbird.net/2024/12/visualizing-the-thunderbird-community-with-bitergia/). |
+| [The Alan Turing Institute](https://www.turing.ac.uk/) | The Alan Turing Institute is using GrimoireLab internally to analyse their public GitHub repos and understand usage and contribution patterns and questions around software maintenance and communities. |
 <!-- to append the table: insert a line above, using the format below
 | [name](URL) | brief description of how you are using GrimoireLab |
 -->

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -122,7 +122,7 @@ asked to log in:
 * Password: `admin`
 
 This version doesn't come with visualizations. You need to manually import the dashboards
-from [Sigils repository](https://github.com/chaoss/grimoirelab-sigils/tree/master/panels/json/opensearch_dashboards)
+from [Sigils repository](https://github.com/chaoss/grimoirelab-sigils/tree/main/panels/json/opensearch_dashboards)
 or create your own.
 
 For more information related with OpenSearch: https://opensearch.org/docs/latest/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,9 +47,9 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG C.UTF-8
 
 # Download basic configuration files
-ADD https://raw.githubusercontent.com/chaoss/grimoirelab-sirmordred/master/aliases.json ${DEPLOY_USER_DIR}/aliases.json
+ADD https://raw.githubusercontent.com/chaoss/grimoirelab-sirmordred/main/aliases.json ${DEPLOY_USER_DIR}/aliases.json
 RUN chmod 444 ${DEPLOY_USER_DIR}/aliases.json
-ADD https://raw.githubusercontent.com/chaoss/grimoirelab-sirmordred/master/menu.yaml ${DEPLOY_USER_DIR}/menu.yaml
+ADD https://raw.githubusercontent.com/chaoss/grimoirelab-sirmordred/main/menu.yaml ${DEPLOY_USER_DIR}/menu.yaml
 RUN chmod 444 ${DEPLOY_USER_DIR}/menu.yaml
 
 ADD stage ${DEPLOY_USER_DIR}/stage

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -11,7 +11,7 @@
                     <a class="text-white" href="https://lists.linuxfoundation.org/mailman/listinfo/grimoirelab-discussions">GrimoireLab mailing list</a> 
                     to get in touch with the <em>community</em>.</p>
                 <p class="text-justify">Contributions are welcome! Please check the 
-                    <a class="text-white" href="https://github.com/chaoss/grimoirelab/blob/master/CONTRIBUTING.md">Contributing Guidelines</a>.</p>
+                    <a class="text-white" href="https://github.com/chaoss/grimoirelab/blob/main/CONTRIBUTING.md">Contributing Guidelines</a>.</p>
             </div>
             <div class="footer-col col-md-6">
                 <h3>Join us!</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@ sections:
     </div>
 
     <div class="text-center mt-4">
-      <a class="btn btn-xl btn-outline-primary" href="https://github.com/chaoss/grimoirelab/blob/master/README.md">
+      <a class="btn btn-xl btn-outline-primary" href="https://github.com/chaoss/grimoirelab/blob/main/README.md">
         <svg class="bi bi-terminal-fill h2" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" d="M0 3a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H2a2 2 0 01-2-2V3zm9.5 5.5h-3a.5.5 0 000 1h3a.5.5 0 000-1zm-6.354-.354L4.793 6.5 3.146 4.854a.5.5 0 11.708-.708l2 2a.5.5 0 010 .708l-2 2a.5.5 0 01-.708-.708z" clip-rule="evenodd"/>
         </svg>


### PR DESCRIPTION
Update files to support the migration of GrimoireLab repositories as part of the default branch transition from master to main.