### PR TITLE
[docker] Include Docker Compose file for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ or visiting the [GrimoireLab website](https://chaoss.github.io/grimoirelab).
 - Redis database >= 7.4
 - OpenSearch >= 2.0
 
+To simplify the setup of the development environment, you can use the provided
+[docker-compose-development.yml](./docker-compose/docker-compose-development.yml)
+file. This file deploys the required services for running GrimoireLab in development
+mode.
+
 Due to this is a development branch, you will have to install
 [poetry](https://python-poetry.org/) first, in order to get other dependencies
 and packages. You can install it following its

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -73,6 +73,27 @@ go to `http://localhost:8000/identities/`. To get access:
 
 **Note**: you can change user and password in the `docker-compose.yml` file.
 
+
+## Using Docker Compose for Development
+
+To simplify the setup of the development environment, you can use the provided
+`docker-compose-development.yml` file. This file deploys the required services
+for running GrimoireLab in development mode.
+
+By default, it includes:
+
+- MariaDB running on port 3306
+- Redis running on port 6379
+- OpenSearch running on port 9200
+- OpenSearch Dashboards running on port 5601
+
+To start the development environment, run the following command:
+
+```  
+docker-compose -f docker-compose-development.yml up -d
+```
+
+
 ## Common questions
 
 ### How to stop and restart deployed software infrastructure?

--- a/docker-compose/docker-compose-development.yml
+++ b/docker-compose/docker-compose-development.yml
@@ -1,0 +1,49 @@
+version: '2.2'
+
+services:
+    mariadb:
+      image: mariadb:11.4
+      ports:
+        - "3306:3306"
+      environment:
+        - MYSQL_ROOT_PASSWORD=
+        - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+      healthcheck:
+        test: [ "CMD", "/usr/local/bin/healthcheck.sh", "--su=root", "--connect", "--innodb_initialized" ]
+        retries: 5
+
+    redis:
+      image: redis:7.4
+      ports:
+        - "6379:6379"
+      healthcheck:
+        test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+        retries: 5
+
+    opensearch-node1:
+      image: opensearchproject/opensearch:2.11.1
+      environment:
+        - cluster.name=opensearch-cluster
+        - node.name=opensearch-node1
+        - discovery.type=single-node
+        - bootstrap.memory_lock=true
+        - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
+        nofile:
+          soft: 65536
+          hard: 65536
+      ports:
+        - 9200:9200
+        - 9600:9600
+
+    opensearch-dashboards:
+      image: opensearchproject/opensearch-dashboards:2.11.1
+      ports:
+        - 5601:5601
+      expose:
+        - "5601"
+      environment:
+        OPENSEARCH_HOSTS: '["https://opensearch-node1:9200"]'


### PR DESCRIPTION
This commit includes the `docker-compose-development.yml` file to deploy the required services for running GrimoireLab in development mode.

By default, it includes MariaDB running on port 3306, Redis on port 6379, OpenSearch on port 9200, and OpenSearch Dashboards on port 5601.