### PR TITLE
Add Subheading to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -24,6 +24,8 @@ The list of organizations that have publicly shared the usage of GrimoireLab:
 | [name](URL) | brief description of how you are using GrimoireLab |
 -->
 
+## Research referencing GrimoireLab
+
 📜 **Add your research papers by creating a PR**
 
 The list of papers that have used GrimoireLab or data produced by it:


### PR DESCRIPTION
Adding a subheading to get a deep link directly to the section of research referencing GrimoireLab.