### PR TITLE
[docker] Update base image to Python 3.12 Debian 12

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) 2016-2022 Bitergia
 # GPLv3 License
 
-FROM python:3.9-slim-bullseye
+FROM python:3.12-slim-bookworm
 LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
This PR updates the image to use Python 3.12 instead of Python 3.9, and the latest stable version of Debian 12 (Bookworm).

Related to https://github.com/chaoss/grimoirelab/issues/779