### PR TITLE
Update the Python version in docker compose

### DIFF
--- a/docker-compose/docker-compose-opensearch.yml
+++ b/docker-compose/docker-compose-opensearch.yml
@@ -83,7 +83,7 @@ services:
       expose:
         - "9314"
       volumes:
-        - sortinghat-static:/opt/venv/lib/python3.9/site-packages/sortinghat/static/
+        - sortinghat-static:/opt/venv/lib/python3.12/site-packages/sortinghat/static/
       depends_on:
         mariadb:
           condition: service_healthy

--- a/docker-compose/docker-compose-secured.yml
+++ b/docker-compose/docker-compose-secured.yml
@@ -74,7 +74,7 @@ services:
       expose:
         - "9314"
       volumes:
-        - sortinghat-static:/opt/venv/lib/python3.9/site-packages/sortinghat/static/
+        - sortinghat-static:/opt/venv/lib/python3.12/site-packages/sortinghat/static/
       depends_on:
         mariadb:
           condition: service_healthy

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       expose:
         - "9314"
       volumes:
-        - sortinghat-static:/opt/venv/lib/python3.9/site-packages/sortinghat/static/
+        - sortinghat-static:/opt/venv/lib/python3.12/site-packages/sortinghat/static/
       depends_on:
         mariadb:
           condition: service_healthy


### PR DESCRIPTION
This PR updates the Python version used in Docker Compose files from Python 3.9 to Python 3.12.