### PR TITLE
Update GrimoireLab 2.x docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,13 +15,17 @@ jobs:
   build-image:
     runs-on: ubuntu-latest
     environment: docker-release
+    permissions:
+      contents: read
+      id-token: write # needed for signing the images with GitHub OIDC Token
+
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: |
             ${{ env.DOCKER_IMAGE_NAME }}
@@ -30,33 +34,35 @@ jobs:
             type=raw,value=${{ inputs.version }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           platforms: linux/arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to DockerHub
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: build-and-push
-        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           platforms: linux/amd64,linux/arm64
           context: "{{defaultContext}}:docker"
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
-      - name: Sign image with a key
-        run: |
-          echo "${TAGS}" | xargs -I {} cosign sign -y -r --key env://COSIGN_PRIVATE_KEY "{}@${DIGEST}"
+      - name: Sign the images with GitHub OIDC Token
         env:
-          TAGS: ${{ steps.meta.outputs.tags }}
-          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
-          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}

--- a/docker-compose/docker-compose-development.yml
+++ b/docker-compose/docker-compose-development.yml
@@ -1,5 +1,3 @@
-version: '2.2'
-
 services:
     mariadb:
       image: mariadb:11.4
@@ -13,7 +11,7 @@ services:
         retries: 5
 
     redis:
-      image: redis:7.4
+      image: redis:8
       ports:
         - "6379:6379"
       healthcheck:
@@ -21,13 +19,14 @@ services:
         retries: 5
 
     opensearch-node1:
-      image: opensearchproject/opensearch:2.11.1
+      image: opensearchproject/opensearch:2.19.3
       environment:
         - cluster.name=opensearch-cluster
         - node.name=opensearch-node1
         - discovery.type=single-node
         - bootstrap.memory_lock=true
         - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
+        - OPENSEARCH_INITIAL_ADMIN_PASSWORD=Admin-Password-1234
       ulimits:
         memlock:
           soft: -1
@@ -40,7 +39,7 @@ services:
         - 9600:9600
 
     opensearch-dashboards:
-      image: opensearchproject/opensearch-dashboards:2.11.1
+      image: opensearchproject/opensearch-dashboards:2.19.3
       ports:
         - 5601:5601
       expose:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.2'
-
 services:
     mariadb:
       image: mariadb:11.4
@@ -13,7 +11,7 @@ services:
         retries: 5
 
     redis:
-      image: redis:7.4
+      image: redis:8
       expose:
         - "6379"
       healthcheck:
@@ -22,7 +20,7 @@ services:
 
     grimoirelab_core:
       restart: on-failure:3
-      image: grimoirelab/grimoirelab:dev
+      image: grimoirelab/grimoirelab:2.x
       environment:
         GRIMOIRELAB_DB_HOST: mariadb
         GRIMOIRELAB_DB_PORT: 3306
@@ -32,8 +30,6 @@ services:
         GRIMOIRELAB_REDIS_HOST: redis
         GRIMOIRELAB_REDIS_PORT: 6379
         GRIMOIRELAB_REDIS_PASSWORD: ""
-        GRIMOIRELAB_ARCHIVIST_WORKERS: 20
-        GRIMOIRELAB_ARCHIVIST_STORAGE_URL: "https://admin:admin@opensearch-node1:9200"
       expose:
         - "9314"
       volumes:
@@ -43,11 +39,11 @@ services:
           condition: service_healthy
         redis:
           condition: service_healthy
-      command: grimoirelab run server --clear-tasks
+      command: grimoirelab run server
 
     grimoirelab_core_eventizers:
       restart: on-failure:3
-      image: grimoirelab/grimoirelab:dev
+      image: grimoirelab/grimoirelab:2.x
       environment:
         GRIMOIRELAB_DB_HOST: mariadb
         GRIMOIRELAB_DB_PORT: 3306
@@ -57,7 +53,6 @@ services:
         GRIMOIRELAB_REDIS_HOST: redis
         GRIMOIRELAB_REDIS_PORT: 6379
         GRIMOIRELAB_REDIS_PASSWORD: ""
-        GRIMOIRELAB_ARCHIVIST_WORKERS: 20
       depends_on:
         mariadb:
           condition: service_healthy
@@ -67,7 +62,7 @@ services:
 
     grimoirelab_core_archivists:
       restart: on-failure:3
-      image: grimoirelab/grimoirelab:dev
+      image: grimoirelab/grimoirelab:2.x
       environment:
         GRIMOIRELAB_DB_HOST: mariadb
         GRIMOIRELAB_DB_PORT: 3306
@@ -77,7 +72,9 @@ services:
         GRIMOIRELAB_REDIS_HOST: redis
         GRIMOIRELAB_REDIS_PORT: 6379
         GRIMOIRELAB_REDIS_PASSWORD: ""
-        GRIMOIRELAB_ARCHIVIST_WORKERS: 20
+        GRIMOIRELAB_ARCHIVIST_STORAGE_URL: "https://opensearch-node1:9200"
+        GRIMOIRELAB_ARCHIVIST_STORAGE_USERNAME: "admin"
+        GRIMOIRELAB_ARCHIVIST_STORAGE_PASSWORD: "Admin-Password-1234"
       depends_on:
         mariadb:
           condition: service_healthy
@@ -106,7 +103,7 @@ services:
       expose:
         - "9314"
       volumes:
-        - sortinghat-static:/opt/venv/lib/python3.9/site-packages/sortinghat/static/
+        - sortinghat-static:/opt/venv/lib/python3.12/site-packages/sortinghat/static/
       depends_on:
         mariadb:
           condition: service_healthy
@@ -131,13 +128,14 @@ services:
           condition: service_healthy
 
     opensearch-node1:
-      image: opensearchproject/opensearch:2.11.1
+      image: opensearchproject/opensearch:2.19.3
       environment:
         - cluster.name=opensearch-cluster
         - node.name=opensearch-node1
         - discovery.type=single-node
         - bootstrap.memory_lock=true
         - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
+        - OPENSEARCH_INITIAL_ADMIN_PASSWORD=Admin-Password-1234
       ulimits:
         memlock:
           soft: -1
@@ -150,7 +148,7 @@ services:
         - 9600:9600
 
     opensearch-dashboards:
-      image: opensearchproject/opensearch-dashboards:2.11.1
+      image: opensearchproject/opensearch-dashboards:2.19.3
       ports:
         - 5601:5601
       expose:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,16 @@
 # Copyright (C) 2016-2022 Bitergia
 # GPLv3 License
 
-FROM node:18 AS build-core-static
-
-RUN git clone --depth 1 https://github.com/chaoss/grimoirelab-core.git
-
-WORKDIR /grimoirelab-core/ui
-
-RUN yarn install && yarn build
-
-
-FROM python:3.11-slim-bullseye
+FROM python:3.12-slim-bullseye
 
 LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEPLOY_USER grimoirelab
-ENV DEPLOY_USER_DIR /home/${DEPLOY_USER}
-ENV CONF_DIR ${DEPLOY_USER_DIR}/conf
-ENV SCRIPTS_DIR ${DEPLOY_USER_DIR}/scripts
-ENV GRIMOIRELAB_RELEASE "2.x"
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEPLOY_USER=grimoirelab
+ENV DEPLOY_USER_DIR=/home/${DEPLOY_USER}
+ENV CONF_DIR=${DEPLOY_USER_DIR}/conf
+ENV SCRIPTS_DIR=${DEPLOY_USER_DIR}/scripts
+ENV GRIMOIRELAB_RELEASE="2.x"
 
 # Create a user and a group
 RUN groupadd -r $DEPLOY_USER && useradd -r -m -g $DEPLOY_USER $DEPLOY_USER
@@ -32,9 +23,19 @@ RUN apt-get update && \
         git git-core \
         mariadb-client \
         libmariadbclient-dev-compat \
-        unzip curl wget sudo ssh \
-        && \
-    apt-get clean && \
+        unzip curl wget sudo ssh
+
+# Install nodejs
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs
+
+# Install yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends yarn
+
+RUN apt-get clean && \
     find /var/lib/apt/lists -type f -delete
 
 RUN echo "${DEPLOY_USER} ALL=NOPASSWD: ALL" >> /etc/sudoers
@@ -44,10 +45,10 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV LANG C.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=C.UTF-8
 
 USER ${DEPLOY_USER}
 
@@ -78,12 +79,11 @@ RUN python -m venv /opt/venv/ && \
     poetry update && \
     poetry install
 
-COPY --from=build-core-static /grimoirelab-core/src/grimoirelab/core/templates/ /opt/venv/lib/python3.11/site-packages/grimoirelab/core/templates/
-
 RUN chown -R $DEPLOY_USER:$DEPLOY_USER /opt/venv
 
+# Make static files available in a known location
 RUN mkdir /core_static/
-COPY --from=build-core-static /grimoirelab-core/src/grimoirelab/core/templates/static/ /core_static/
+RUN cp -r /opt/venv/lib/python3.12/site-packages/grimoirelab/core/templates/static/. /core_static/
 RUN chown -R $DEPLOY_USER:$DEPLOY_USER /core_static/
 
 COPY ./entrypoint.sh /usr/local/bin/

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,20 +24,16 @@ set -e
 export GRIMOIRELAB_CONFIG="${GRIMOIRELAB_CONFIG:-grimoirelab.core.config.settings}"
 
 check_service() {
-    django-admin check --settings=$GRIMOIRELAB_CONFIG --database default > /dev/null 2>&1
+    django-admin check --settings="$GRIMOIRELAB_CONFIG" --database default > /dev/null 2>&1
     return $?
 }
 
-# Only if the command is grimoirelab, setup the database
+# If running `grimoirelab run`, always ensure the database is up-to-date.
+# Otherwise, only set it up if the check fails.
 if [ "$1" = 'grimoirelab' ]; then
-    if ! check_service ; then
+  if [ "$2" = 'run' ] || ! check_service; then
         grimoirelab admin setup
-
-        if [ "$?" -ne "0" ]; then
-            echo "GrimoireLab core setup failed."
-            return 1
-        fi
-    fi
+  fi
 fi
 
 exec "$@"


### PR DESCRIPTION
Update Docker workflow to sign the image using GitHub OIDC in keyless mode and update the workflow actions to the latest version.

Update docker-compose and Dockerfile with the latest changes in GrimoireLab core.


